### PR TITLE
[#1] 음성 1:N 브로드캐스팅 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	// websocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	// sfu
+	implementation group: 'org.kurento', name: 'kurento-client', version: '7.1.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/eightplusone/bit/fit/global/config/AudioWebSocketConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/AudioWebSocketConfig.java
@@ -1,0 +1,29 @@
+package eightplusone.bit.fit.global.config;
+
+import eightplusone.bit.fit.global.websocket.CallHandler;
+import org.kurento.client.KurentoClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@EnableWebSocket
+@Configuration
+public class AudioWebSocketConfig implements WebSocketConfigurer {
+
+    @Bean
+    public CallHandler callHandler() {
+        return new CallHandler();
+    }
+
+    @Bean
+    public KurentoClient kurentoClient()  {
+        return KurentoClient.create("ws://localhost:8888/kurento");
+    }
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(callHandler(), "/call").setAllowedOrigins("*");;
+    }
+}

--- a/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
@@ -1,0 +1,249 @@
+package eightplusone.bit.fit.global.websocket;
+/*
+ * (C) Copyright 2014 Kurento (http://kurento.org/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.kurento.client.*;
+import org.kurento.jsonrpc.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Protocol handler for 1 to N video call communication.
+ *
+ * @author Boni Garcia (bgarcia@gsyc.es)
+ * @since 5.0.0
+ */
+public class CallHandler extends TextWebSocketHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(CallHandler.class);
+    private static final Gson gson = new GsonBuilder().create();
+
+    private final ConcurrentHashMap<String, UserSession> viewers = new ConcurrentHashMap<>();
+
+    @Autowired
+    private KurentoClient kurento;
+
+    private MediaPipeline pipeline;
+    private UserSession presenterUserSession;
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        JsonObject jsonMessage = gson.fromJson(message.getPayload(), JsonObject.class);
+        log.debug("Incoming message from session '{}': {}", session.getId(), jsonMessage);
+
+        switch (jsonMessage.get("id").getAsString()) {
+            case "presenter":
+                try {
+                    presenter(session, jsonMessage);
+                } catch (Throwable t) {
+                    handleErrorResponse(t, session, "presenterResponse");
+                }
+                break;
+            case "viewer":
+                try {
+                    viewer(session, jsonMessage);
+                } catch (Throwable t) {
+                    handleErrorResponse(t, session, "viewerResponse");
+                }
+                break;
+            case "onIceCandidate": {
+                JsonObject candidate = jsonMessage.get("candidate").getAsJsonObject();
+
+                UserSession user = null;
+                if (presenterUserSession != null) {
+                    if (presenterUserSession.getSession() == session) {
+                        user = presenterUserSession;
+                    } else {
+                        user = viewers.get(session.getId());
+                    }
+                }
+                if (user != null) {
+                    IceCandidate cand =
+                            new IceCandidate(candidate.get("candidate").getAsString(), candidate.get("sdpMid")
+                                    .getAsString(), candidate.get("sdpMLineIndex").getAsInt());
+                    user.addCandidate(cand);
+                }
+                break;
+            }
+            case "stop":
+                stop(session);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void handleErrorResponse(Throwable throwable, WebSocketSession session, String responseId)
+            throws IOException {
+        stop(session);
+        log.error(throwable.getMessage(), throwable);
+        JsonObject response = new JsonObject();
+        response.addProperty("id", responseId);
+        response.addProperty("response", "rejected");
+        response.addProperty("message", throwable.getMessage());
+        session.sendMessage(new TextMessage(response.toString()));
+    }
+
+    private synchronized void presenter(final WebSocketSession session, JsonObject jsonMessage)
+            throws IOException {
+        if (presenterUserSession == null) {
+            presenterUserSession = new UserSession(session);
+
+            pipeline = kurento.createMediaPipeline();
+            presenterUserSession.setWebRtcEndpoint(new WebRtcEndpoint.Builder(pipeline).build());
+
+            WebRtcEndpoint presenterWebRtc = presenterUserSession.getWebRtcEndpoint();
+
+            presenterWebRtc.addIceCandidateFoundListener(new EventListener<IceCandidateFoundEvent>() {
+
+                @Override
+                public void onEvent(IceCandidateFoundEvent event) {
+                    JsonObject response = new JsonObject();
+                    response.addProperty("id", "iceCandidate");
+                    response.add("candidate", JsonUtils.toJsonObject(event.getCandidate()));
+                    try {
+                        synchronized (session) {
+                            session.sendMessage(new TextMessage(response.toString()));
+                        }
+                    } catch (IOException e) {
+                        log.debug(e.getMessage());
+                    }
+                }
+            });
+
+            String sdpOffer = jsonMessage.getAsJsonPrimitive("sdpOffer").getAsString();
+            String sdpAnswer = presenterWebRtc.processOffer(sdpOffer);
+
+            JsonObject response = new JsonObject();
+            response.addProperty("id", "presenterResponse");
+            response.addProperty("response", "accepted");
+            response.addProperty("sdpAnswer", sdpAnswer);
+
+            synchronized (session) {
+                presenterUserSession.sendMessage(response);
+            }
+            presenterWebRtc.gatherCandidates();
+
+        } else {
+            JsonObject response = new JsonObject();
+            response.addProperty("id", "presenterResponse");
+            response.addProperty("response", "rejected");
+            response.addProperty("message",
+                    "Another user is currently acting as sender. Try again later ...");
+            session.sendMessage(new TextMessage(response.toString()));
+        }
+    }
+
+    private synchronized void viewer(final WebSocketSession session, JsonObject jsonMessage)
+            throws IOException {
+        if (presenterUserSession == null || presenterUserSession.getWebRtcEndpoint() == null) {
+            JsonObject response = new JsonObject();
+            response.addProperty("id", "viewerResponse");
+            response.addProperty("response", "rejected");
+            response.addProperty("message",
+                    "No active sender now. Become sender or . Try again later ...");
+            session.sendMessage(new TextMessage(response.toString()));
+        } else {
+            if (viewers.containsKey(session.getId())) {
+                JsonObject response = new JsonObject();
+                response.addProperty("id", "viewerResponse");
+                response.addProperty("response", "rejected");
+                response.addProperty("message", "You are already viewing in this session. "
+                        + "Use a different browser to add additional viewers.");
+                session.sendMessage(new TextMessage(response.toString()));
+                return;
+            }
+            UserSession viewer = new UserSession(session);
+            viewers.put(session.getId(), viewer);
+
+            WebRtcEndpoint nextWebRtc = new WebRtcEndpoint.Builder(pipeline).build();
+
+            nextWebRtc.addIceCandidateFoundListener(new EventListener<IceCandidateFoundEvent>() {
+
+                @Override
+                public void onEvent(IceCandidateFoundEvent event) {
+                    JsonObject response = new JsonObject();
+                    response.addProperty("id", "iceCandidate");
+                    response.add("candidate", JsonUtils.toJsonObject(event.getCandidate()));
+                    try {
+                        synchronized (session) {
+                            session.sendMessage(new TextMessage(response.toString()));
+                        }
+                    } catch (IOException e) {
+                        log.debug(e.getMessage());
+                    }
+                }
+            });
+
+            viewer.setWebRtcEndpoint(nextWebRtc);
+            presenterUserSession.getWebRtcEndpoint().connect(nextWebRtc);
+            String sdpOffer = jsonMessage.getAsJsonPrimitive("sdpOffer").getAsString();
+            String sdpAnswer = nextWebRtc.processOffer(sdpOffer);
+
+            JsonObject response = new JsonObject();
+            response.addProperty("id", "viewerResponse");
+            response.addProperty("response", "accepted");
+            response.addProperty("sdpAnswer", sdpAnswer);
+
+            synchronized (session) {
+                viewer.sendMessage(response);
+            }
+            nextWebRtc.gatherCandidates();
+        }
+    }
+
+    private synchronized void stop(WebSocketSession session) throws IOException {
+        String sessionId = session.getId();
+        if (presenterUserSession != null && presenterUserSession.getSession().getId().equals(sessionId)) {
+            for (UserSession viewer : viewers.values()) {
+                JsonObject response = new JsonObject();
+                response.addProperty("id", "stopCommunication");
+                viewer.sendMessage(response);
+            }
+
+            log.info("Releasing media pipeline");
+            if (pipeline != null) {
+                pipeline.release();
+            }
+            pipeline = null;
+            presenterUserSession = null;
+        } else if (viewers.containsKey(sessionId)) {
+            if (viewers.get(sessionId).getWebRtcEndpoint() != null) {
+                viewers.get(sessionId).getWebRtcEndpoint().release();
+            }
+            viewers.remove(sessionId);
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        stop(session);
+    }
+
+}

--- a/src/main/java/eightplusone/bit/fit/global/websocket/UserSession.java
+++ b/src/main/java/eightplusone/bit/fit/global/websocket/UserSession.java
@@ -1,0 +1,68 @@
+package eightplusone.bit.fit.global.websocket;
+
+/*
+ * (C) Copyright 2014 Kurento (http://kurento.org/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+import com.google.gson.JsonObject;
+import org.kurento.client.IceCandidate;
+import org.kurento.client.WebRtcEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+
+/**
+ * User session.
+ *
+ * @author Boni Garcia (bgarcia@gsyc.es)
+ * @since 5.0.0
+ */
+public class UserSession {
+
+    private static final Logger log = LoggerFactory.getLogger(UserSession.class);
+
+    private final WebSocketSession session;
+    private WebRtcEndpoint webRtcEndpoint;
+
+    public UserSession(WebSocketSession session) {
+        this.session = session;
+    }
+
+    public WebSocketSession getSession() {
+        return session;
+    }
+
+    public void sendMessage(JsonObject message) throws IOException {
+        log.debug("Sending message from user with session Id '{}': {}", session.getId(), message);
+        session.sendMessage(new TextMessage(message.toString()));
+    }
+
+    public WebRtcEndpoint getWebRtcEndpoint() {
+        return webRtcEndpoint;
+    }
+
+    public void setWebRtcEndpoint(WebRtcEndpoint webRtcEndpoint) {
+        this.webRtcEndpoint = webRtcEndpoint;
+    }
+
+    public void addCandidate(IceCandidate candidate) {
+        webRtcEndpoint.addIceCandidate(candidate);
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#1](https://github.com/FiT-8-plus-1-BiT/backend/issues/1)


### 변경 사항
쿠렌토 공식 깃허브 기반 음성 1:N 브로드캐스팅 기능을 추가했습니다.
Config 이름을 AudioWebSocketConfig로 변경했습니다.
쿠렌토 빈에 "ws://localhost:8888/kurento" 로 쿠렌토 연결을 명시한 것 이외 변경사항이 없습니다.
(패키지 위치 및 이름은 이후 유동적으로 변경하셔도 됩니다 !)

### 테스트 결과
- PostMan 웹소켓 연결 테스트 완료 
- 예시 React 연결 테스트 완료
![스크린샷 2025-03-04 오후 4 48 38](https://github.com/user-attachments/assets/243970e5-d610-4e04-b72a-3953821994bc)

| 테스트에 사용된 React 코드는 노션을 확인해주세요 !


