### PR TITLE
[#4] 소셜로그인 부가 기능 구현

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/auth/controller/AuthController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/controller/AuthController.java
@@ -1,0 +1,61 @@
+package eightplusone.bit.fit.domain.auth.controller;
+
+import static eightplusone.bit.fit.global.constants.TokenConstant.*;
+import static eightplusone.bit.fit.global.utils.CookieUtil.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.Date;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.utils.CookieUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final TokenProvider tokenProvider;
+
+	@PostMapping("/reissue")
+	public ResponseEntity<?> reissue(HttpServletRequest request) {
+		String accessToken = tokenProvider.resolveAccessToken(request);
+		Claims claimsByAccessToken = tokenProvider.getClaimsByAccessToken(accessToken);
+
+		String role = claimsByAccessToken.get(AUTHORITIES_KEY).toString();
+		String subject = claimsByAccessToken.getSubject();
+		String requestRefreshToken = CookieUtil.findCookieByName(request, REFRESH_TOKEN_COOKIE_NAME).getValue();
+
+		boolean isValid = tokenProvider.validateRefreshTokenWithAccessTokenInfo(role, subject, requestRefreshToken);
+		if (!isValid) {
+			return ResponseEntity.status(UNAUTHORIZED)
+				.header(
+					HttpHeaders.SET_COOKIE,
+					createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
+				.body(null);
+		}
+
+		String newAccessToken = tokenProvider.createAccessToken(subject, role, new Date());
+		return ResponseEntity.status(OK)
+			.header(AUTHORIZATION, newAccessToken)
+			.body(null);
+	}
+
+	@PostMapping("/token-exchange")
+	public ResponseEntity<?> exchange(HttpServletRequest request) {
+		String accessToken = CookieUtil.findCookieByName(request, ACCESS_TOKEN_COOKIE_NAME).getValue();
+		return ResponseEntity.status(OK)
+			.header(AUTHORIZATION, BEARER_PREFIX + accessToken)
+			.header(SET_COOKIE, createCookie(ACCESS_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
+			.body(null);
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
@@ -1,0 +1,68 @@
+package eightplusone.bit.fit.domain.auth.filter;
+
+import static eightplusone.bit.fit.global.constants.TokenConstant.*;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.GenericFilterBean;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.utils.CookieUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomLogoutFilter extends GenericFilterBean {
+
+	private final TokenProvider tokenProvider;
+	private final ObjectMapper objectMapper;
+
+	public CustomLogoutFilter(TokenProvider tokenProvider, ObjectMapper objectMapper) {
+		this.tokenProvider = tokenProvider;
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws
+		IOException,
+		ServletException {
+		doFilter((HttpServletRequest)request, (HttpServletResponse)response, chain);
+	}
+
+	private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
+		IOException,
+		ServletException {
+		if (!request.getRequestURI().equals("/auth/logout") || !request.getMethod().equals("POST")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String accessToken = tokenProvider.resolveAccessToken(request);
+		Claims claimsByAccessToken = tokenProvider.getClaimsByAccessToken(accessToken);
+
+		String id = claimsByAccessToken.getSubject();
+		String role = claimsByAccessToken.get(AUTHORITIES_KEY).toString();
+
+		tokenProvider.invalidateRefreshToken(id);
+
+		log.info("{}-{}: logout ({})", id, role, new Date());
+		response.addHeader(HttpHeaders.SET_COOKIE,
+			CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString());
+		response.setStatus(HttpServletResponse.SC_OK);
+		response.setCharacterEncoding("utf-8");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(objectMapper.writeValueAsString(null));
+	}
+}
+

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
@@ -43,7 +43,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 	private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws
 		IOException,
 		ServletException {
-		if (!request.getRequestURI().equals("/auth/logout") || !request.getMethod().equals("POST")) {
+		if (!request.getRequestURI().equals("/api/v1/auth/logout") || !request.getMethod().equals("POST")) {
 			filterChain.doFilter(request, response);
 			return;
 		}

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
@@ -51,12 +51,12 @@ public class CustomLogoutFilter extends GenericFilterBean {
 		String accessToken = tokenProvider.resolveAccessToken(request);
 		Claims claimsByAccessToken = tokenProvider.getClaimsByAccessToken(accessToken);
 
-		String id = claimsByAccessToken.getSubject();
+		String email = claimsByAccessToken.getSubject();
 		String role = claimsByAccessToken.get(AUTHORITIES_KEY).toString();
 
-		tokenProvider.invalidateRefreshToken(id);
+		tokenProvider.invalidateRefreshToken(email);
 
-		log.info("{}-{}: logout ({})", id, role, new Date());
+		log.info("{}-{}: logout ({})", email, role, new Date());
 		response.addHeader(HttpHeaders.SET_COOKIE,
 			CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString());
 		response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package eightplusone.bit.fit.domain.auth.filter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -8,6 +9,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.enums.ApiEndpoint;
 import io.jsonwebtoken.IncorrectClaimException;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
@@ -61,6 +63,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
-		return requestUri.equals("/api/v1/auth/reissue") || requestUri.equals("/api/v1/auth/token-exchange");
+		return Arrays.stream(ApiEndpoint.values())
+			.filter(endpoint -> endpoint.name().startsWith("PUBLIC_"))
+			.flatMap(endpoint -> Arrays.stream(endpoint.getPaths()))
+			.map(path -> path.replace("**", ".*"))
+			.anyMatch(requestUri::matches);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import io.jsonwebtoken.IncorrectClaimException;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,24 +41,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		String accessToken = tokenProvider.resolveAccessToken(request);
 
 		try {
-			if (accessToken != null && tokenProvider.validateAccessToken(accessToken)) {
-				Authentication authentication = tokenProvider.getAuthenticationByAccessToken(accessToken);
-				SecurityContextHolder.getContext().setAuthentication(authentication);
+			if (!tokenProvider.validateAccessToken(accessToken)) {
+				throw new JwtException("잘못된 토큰 입니다.");
 			}
+			Authentication authentication = tokenProvider.getAuthenticationByAccessToken(accessToken);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+
 		} catch (IncorrectClaimException e) {
 			SecurityContextHolder.clearContext();
 			log.debug("잘못된 토큰 입니다.");
-			response.sendError(403);
+			throw new JwtException("잘못된 토큰 입니다.", e);
 		} catch (UsernameNotFoundException e) {
 			SecurityContextHolder.clearContext();
-			log.debug("회원을 찾을 수 없습니다..");
-			response.sendError(403);
+			log.debug("회원을 찾을 수 없습니다.");
+			throw new UsernameNotFoundException("회원을 찾을 수 없습니다.");
 		}
 		filterChain.doFilter(request, response);
 	}
 
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
-		return requestUri.equals("/reissue"); // TODO: API 스펙에 맞게 수정 할 것
+		return requestUri.equals("/api/v1/auth/reissue") || requestUri.equals("/api/v1/auth/token-exchange");
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package eightplusone.bit.fit.domain.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException {
+
+		response.setStatus(HttpStatus.FORBIDDEN.value());
+		response.setCharacterEncoding("utf-8");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(objectMapper.writeValueAsString("권한이 없습니다"));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package eightplusone.bit.fit.domain.auth.handler;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException) throws IOException {
+
+		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+		response.setCharacterEncoding("utf-8");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(objectMapper.writeValueAsString("잘못된 접근 입니다."));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomOAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomOAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,30 @@
+package eightplusone.bit.fit.domain.auth.handler;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomOAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+
+	private final String allowedOrigins;
+
+	public CustomOAuth2AuthenticationFailureHandler(@Value("${cors.allow.origins}") String allowedOrigins) {
+		this.allowedOrigins = allowedOrigins;
+	}
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException {
+		String errorMessage = URLEncoder.encode("social_login_duplicate", StandardCharsets.UTF_8);
+		response.sendRedirect(allowedOrigins + "?error=" + errorMessage);
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomOAuth2SuccessHandler.java
@@ -5,6 +5,7 @@ import static eightplusone.bit.fit.global.constants.TokenConstant.*;
 import java.io.IOException;
 import java.util.Date;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -15,15 +16,20 @@ import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.global.utils.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
 	private final TokenProvider tokenProvider;
+	private final String allowedOrigins;
+
+	public CustomOAuth2SuccessHandler(TokenProvider tokenProvider,
+		@Value("${cors.allow.origins}") String allowedOrigins) {
+		this.tokenProvider = tokenProvider;
+		this.allowedOrigins = allowedOrigins;
+	}
 
 	@Override
 	public void onAuthenticationSuccess(
@@ -44,7 +50,7 @@ public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHa
 		response.addHeader(HttpHeaders.SET_COOKIE,
 			CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken,
 				tokenProvider.getRefreshTokenExpirationSeconds()).toString());
-		response.sendRedirect("http://localhost:3000/main "); //TODO: 이후 프론트 측 에서 원하는 경로로 수정 할 것.
+		response.sendRedirect(allowedOrigins + "/main"); //TODO: 이후 프론트 측 에서 원하는 경로로 수정 할 것.
 		log.info("{}-{}: login ({})", email, role, new Date());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/service/OAuth2UnlinkService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/service/OAuth2UnlinkService.java
@@ -1,0 +1,101 @@
+package eightplusone.bit.fit.domain.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class OAuth2UnlinkService {
+
+	private static final String GOOGLE_URL = "https://oauth2.googleapis.com/revoke";
+	private static final String KAKAO_URL = "https://kapi.kakao.com/v1/user/unlink";
+	private static final String NAVER_URL = "https://nid.naver.com/oauth2.0/token";
+
+	private final RestTemplate restTemplate = new RestTemplate();
+	private final RedisTokenService redisTokenService;
+
+	@Value("${spring.security.oauth2.client.registration.naver.client-id}")
+	private static String NAVER_CLIENT_ID;
+	@Value("${spring.security.oauth2.client.registration.naver.client-secret}")
+	private static String NAVER_CLIENT_SECRET;
+
+	public void unlink(String provider) {
+		if (provider.startsWith("google")) {
+			googleUnlink(provider);
+		} else if (provider.startsWith("kakao")) {
+			kakaoUnlink(provider);
+		} else if (provider.startsWith("naver")) {
+			naverUnlink(provider);
+		} else {
+			throw new IllegalStateException("허용되지 않은 소셜 로그인 제공자");
+		}
+	}
+	
+	private void googleUnlink(String provider) {
+		String accessToken = redisTokenService.getOauth2AccessToken(provider);
+		// oauth2 토큰이 만료 시 재 로그인
+		if (accessToken == null) {
+			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+		}
+		// 바디 설정
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("token", accessToken);
+		restTemplate.postForObject(GOOGLE_URL, params, String.class);
+	}
+
+	private void kakaoUnlink(String provider) {
+		String accessToken = redisTokenService.getOauth2AccessToken(provider);
+		// oauth2 토큰이 만료 시 재 로그인
+		if (accessToken == null) {
+			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setBearerAuth(accessToken);
+		HttpEntity<Object> entity = new HttpEntity<>("", headers);
+		restTemplate.exchange(KAKAO_URL, HttpMethod.POST, entity, String.class);
+	}
+
+	private void naverUnlink(String provider) {
+
+		String accessToken = redisTokenService.getOauth2AccessToken(provider);
+
+		if (accessToken == null) {
+			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+		}
+
+		String url = NAVER_URL
+			+ "?service_provider=NAVER"
+			+ "&grant_type=delete"
+			+ "&client_id="
+			+ NAVER_CLIENT_ID
+			+ "&client_secret="
+			+ NAVER_CLIENT_SECRET
+			+ "&access_token="
+			+ accessToken;
+
+		NaverUnlinkResponse response = restTemplate.getForObject(url, NaverUnlinkResponse.class);
+
+		if (response != null && !"success".equalsIgnoreCase(response.getResult())) {
+			throw new IllegalStateException("소셜 로그인 연결 끊기 실패");
+		}
+	}
+
+	@Getter
+	@RequiredArgsConstructor
+	public static class NaverUnlinkResponse {
+		@JsonProperty("access_token")
+		private final String accessToken;
+		private final String result;
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -1,0 +1,31 @@
+package eightplusone.bit.fit.domain.user.controller;
+
+import static eightplusone.bit.fit.global.constants.TokenConstant.*;
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.user.service.UserService;
+import eightplusone.bit.fit.global.utils.CookieUtil;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+	private final UserService userService;
+
+	@DeleteMapping
+	public ResponseEntity<?> delete() {
+		userService.delete();
+		return ResponseEntity.status(CREATED)
+			.header(HttpHeaders.SET_COOKIE,
+				CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
+			.body(null);
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/repository/UserRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
 	User findLoginUserByEmail(String email);
+
+	void deleteByEmail(String email);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/repository/UserRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/repository/UserRepository.java
@@ -11,6 +11,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByEmail(String email);
 
 	User findLoginUserByEmail(String email);
-
-	void deleteByEmail(String email);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -1,0 +1,36 @@
+package eightplusone.bit.fit.domain.user.service;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
+import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final RedisTokenService redisTokenService;
+	private final OAuth2UnlinkService oAuth2UnlinkService;
+
+	@Transactional
+	public void delete() {
+		String email = SecurityContextHolder.getContext().getAuthentication().getName();
+		userRepository.deleteByEmail(email);
+		deleteOauth2AccessToken(email);
+	}
+
+	private void deleteOauth2AccessToken(String email) {
+		if (email.startsWith("kakao") || email.startsWith("google") || email.startsWith("naver")) {
+			oAuth2UnlinkService.unlink(email);
+		}
+		if (redisTokenService.getOauth2AccessToken(email) != null) {
+			redisTokenService.deleteOauth2AccessToken(email);
+		}
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -21,16 +22,17 @@ public class UserService {
 	@Transactional
 	public void delete() {
 		String email = SecurityContextHolder.getContext().getAuthentication().getName();
-		userRepository.deleteByEmail(email);
-		deleteOauth2AccessToken(email);
+		User user = userRepository.findLoginUserByEmail(email);
+		userRepository.delete(user);
+		deleteOauth2AccessToken(user.getProvider());
 	}
 
-	private void deleteOauth2AccessToken(String email) {
-		if (email.startsWith("kakao") || email.startsWith("google") || email.startsWith("naver")) {
-			oAuth2UnlinkService.unlink(email);
+	private void deleteOauth2AccessToken(String provider) {
+		if (provider.startsWith("kakao") || provider.startsWith("google") || provider.startsWith("naver")) {
+			oAuth2UnlinkService.unlink(provider);
 		}
-		if (redisTokenService.getOauth2AccessToken(email) != null) {
-			redisTokenService.deleteOauth2AccessToken(email);
+		if (redisTokenService.getOauth2AccessToken(provider) != null) {
+			redisTokenService.deleteOauth2AccessToken(provider);
 		}
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -87,8 +88,8 @@ public class SecurityConfig {
 				.anyRequest()
 				.permitAll() // 모든 요청 허용
 			)
-			.addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
-			.addFilterAfter(new CustomLogoutFilter(tokenProvider, objectMapper), JwtAuthenticationFilter.class)
+			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new CustomLogoutFilter(tokenProvider, objectMapper), LogoutFilter.class)
 			.oauth2Login((oauth2) -> oauth2.userInfoEndpoint(
 					(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService)))
 				.successHandler(new CustomOAuth2SuccessHandler(tokenProvider, allowedOrigins))

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -56,9 +56,9 @@ public class SecurityConfig {
 			.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
 				CorsConfiguration configuration = new CorsConfiguration();
 				configuration.setAllowedOrigins(Collections.singletonList(allowedOrigins));
-				configuration.setAllowedMethods(Collections.singletonList(ALLOWED_METHODS));
+				configuration.setAllowedMethods(ALLOWED_METHODS);
 				configuration.setAllowCredentials(ALLOWED_CREDENTIALS);
-				configuration.setAllowedHeaders(Collections.singletonList(ALLOWED_HEADERS));
+				configuration.setAllowedHeaders(ALLOWED_HEADERS);
 				configuration.setMaxAge(MAX_AGE);
 				configuration.setExposedHeaders(Collections.singletonList(HttpHeaders.SET_COOKIE));
 				configuration.setExposedHeaders(Collections.singletonList(HttpHeaders.AUTHORIZATION));

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package eightplusone.bit.fit.global.config;
 
 import static eightplusone.bit.fit.global.constants.CorsConstant.*;
+import static eightplusone.bit.fit.global.enums.ApiEndpoint.*;
 
 import java.util.Collections;
 
@@ -14,13 +15,15 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import eightplusone.bit.fit.domain.auth.enums.Role;
 import eightplusone.bit.fit.domain.auth.filter.CustomLogoutFilter;
 import eightplusone.bit.fit.domain.auth.filter.JwtAuthenticationFilter;
+import eightplusone.bit.fit.domain.auth.handler.CustomAccessDeniedHandler;
+import eightplusone.bit.fit.domain.auth.handler.CustomAuthenticationEntryPoint;
 import eightplusone.bit.fit.domain.auth.handler.CustomOAuth2AuthenticationFailureHandler;
 import eightplusone.bit.fit.domain.auth.handler.CustomOAuth2SuccessHandler;
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
@@ -31,7 +34,6 @@ import eightplusone.bit.fit.domain.auth.service.CustomOAuth2UserService;
 public class SecurityConfig {
 
 	private final String allowedOrigins;
-
 	private final TokenProvider tokenProvider;
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final ObjectMapper objectMapper;
@@ -66,15 +68,34 @@ public class SecurityConfig {
 			.httpBasic(AbstractHttpConfigurer::disable)
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.anyRequest().permitAll() // 모든 요청 허용
+				.requestMatchers(PUBLIC_GET.getMethod(), PUBLIC_GET.getPaths())
+				.permitAll()
+				.requestMatchers(PUBLIC_POST.getMethod(), PUBLIC_POST.getPaths())
+				.permitAll()
+
+				.requestMatchers(AUTHENTICATED_GET.getMethod(), AUTHENTICATED_GET.getPaths())
+				.hasAuthority(Role.USER.getKey())
+				.requestMatchers(AUTHENTICATED_POST.getMethod(), AUTHENTICATED_POST.getPaths())
+				.hasAuthority(Role.USER.getKey())
+				.requestMatchers(AUTHENTICATED_PUT.getMethod(), AUTHENTICATED_PUT.getPaths())
+				.hasAuthority(Role.USER.getKey())
+				.requestMatchers(AUTHENTICATED_PATCH.getMethod(), AUTHENTICATED_PATCH.getPaths())
+				.hasAuthority(Role.USER.getKey())
+				.requestMatchers(AUTHENTICATED_DELETE.getMethod(), AUTHENTICATED_DELETE.getPaths())
+				.hasAuthority(Role.USER.getKey())
+
+				.anyRequest()
+				.permitAll() // 모든 요청 허용
 			)
-			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
-			.addFilterBefore(new CustomLogoutFilter(tokenProvider, objectMapper), LogoutFilter.class)
+			.addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterAfter(new CustomLogoutFilter(tokenProvider, objectMapper), JwtAuthenticationFilter.class)
 			.oauth2Login((oauth2) -> oauth2.userInfoEndpoint(
 					(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService)))
 				.successHandler(new CustomOAuth2SuccessHandler(tokenProvider, allowedOrigins))
-				.failureHandler(new CustomOAuth2AuthenticationFailureHandler(allowedOrigins))
-			);
+				.failureHandler(new CustomOAuth2AuthenticationFailureHandler(allowedOrigins)))
+			.exceptionHandling((exceptionHandling) -> exceptionHandling
+				.authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper))
+				.accessDeniedHandler(new CustomAccessDeniedHandler(objectMapper)));
 
 		return http.build();
 	}

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -14,24 +14,38 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
 import org.springframework.web.cors.CorsConfiguration;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eightplusone.bit.fit.domain.auth.filter.CustomLogoutFilter;
 import eightplusone.bit.fit.domain.auth.filter.JwtAuthenticationFilter;
+import eightplusone.bit.fit.domain.auth.handler.CustomOAuth2AuthenticationFailureHandler;
 import eightplusone.bit.fit.domain.auth.handler.CustomOAuth2SuccessHandler;
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.domain.auth.service.CustomOAuth2UserService;
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
 
-	@Value("${cors.allow.origins}")
-	private static String allowedOrigins;
+	private final String allowedOrigins;
 
 	private final TokenProvider tokenProvider;
 	private final CustomOAuth2UserService customOAuth2UserService;
+	private final ObjectMapper objectMapper;
+
+	public SecurityConfig(
+		@Value("${cors.allow.origins}") String allowedOrigins,
+		TokenProvider tokenProvider,
+		CustomOAuth2UserService customOAuth2UserService,
+		ObjectMapper objectMapper) {
+		this.allowedOrigins = allowedOrigins;
+		this.tokenProvider = tokenProvider;
+		this.customOAuth2UserService = customOAuth2UserService;
+		this.objectMapper = objectMapper;
+	}
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -55,9 +69,11 @@ public class SecurityConfig {
 				.anyRequest().permitAll() // 모든 요청 허용
 			)
 			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(new CustomLogoutFilter(tokenProvider, objectMapper), LogoutFilter.class)
 			.oauth2Login((oauth2) -> oauth2.userInfoEndpoint(
 					(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService)))
-				.successHandler(new CustomOAuth2SuccessHandler(tokenProvider))
+				.successHandler(new CustomOAuth2SuccessHandler(tokenProvider, allowedOrigins))
+				.failureHandler(new CustomOAuth2AuthenticationFailureHandler(allowedOrigins))
 			);
 
 		return http.build();

--- a/src/main/java/eightplusone/bit/fit/global/constants/CorsConstant.java
+++ b/src/main/java/eightplusone/bit/fit/global/constants/CorsConstant.java
@@ -1,9 +1,11 @@
 package eightplusone.bit.fit.global.constants;
 
+import java.util.List;
+
 public class CorsConstant {
 
-	public static final String ALLOWED_METHODS = "GET, POST, PUT, DELETE, OPTIONS";
-	public static final String ALLOWED_HEADERS = "X-Requested-With, Content-Type, Accept";
+	public static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PUT", "DELETE", "OPTIONS");
+	public static final List<String> ALLOWED_HEADERS = List.of("X-Requested-With", "Content-Type", "Accept");
 	public static final boolean ALLOWED_CREDENTIALS = true;
 	public static final long MAX_AGE = 3600L;
 }

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -1,0 +1,45 @@
+package eightplusone.bit.fit.global.enums;
+
+import org.springframework.http.HttpMethod;
+
+import lombok.Getter;
+
+@Getter
+public enum ApiEndpoint {
+
+	PUBLIC_GET(HttpMethod.GET, new String[] {
+		"/swagger-ui/**",
+		"/actuator/**",
+		"/v3/api-docs/**",
+	}),
+
+	PUBLIC_POST(HttpMethod.POST, new String[] {
+		"/api/v1/auth/reissue",
+		"/api/v1/auth/token-exchange"
+	}),
+
+	AUTHENTICATED_GET(HttpMethod.GET, new String[] {
+	}),
+
+	AUTHENTICATED_POST(HttpMethod.POST, new String[] {
+		"/api/v1/auth/logout"
+	}),
+
+	AUTHENTICATED_PUT(HttpMethod.PUT, new String[] {
+	}),
+
+	AUTHENTICATED_PATCH(HttpMethod.PATCH, new String[] {
+	}),
+
+	AUTHENTICATED_DELETE(HttpMethod.DELETE, new String[] {
+	});
+
+	private final HttpMethod method;
+	private final String[] paths;
+
+	ApiEndpoint(HttpMethod method, String[] paths) {
+		this.method = method;
+		this.paths = paths;
+	}
+}
+

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -32,6 +32,7 @@ public enum ApiEndpoint {
 	}),
 
 	AUTHENTICATED_DELETE(HttpMethod.DELETE, new String[] {
+		"/api/v1/users"
 	});
 
 	private final HttpMethod method;

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -10,7 +10,7 @@ public enum ApiEndpoint {
 	PUBLIC_GET(HttpMethod.GET, new String[] {
 		"/swagger-ui/**",
 		"/actuator/**",
-		"/v3/api-docs/**",
+		"/v3/**",
 	}),
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
+++ b/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
@@ -25,6 +25,6 @@ public final class CookieUtil {
 				}
 			}
 		}
-		return null;
+		throw new NullPointerException(name + " 쿠키를 찾을 수 없습니다.");
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,141 @@
+package eightplusone.bit.fit.domain.auth.controller;
+
+import static eightplusone.bit.fit.global.constants.TokenConstant.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.http.HttpHeaders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.domain.auth.service.CustomOAuth2UserService;
+import eightplusone.bit.fit.global.config.SecurityConfig;
+import eightplusone.bit.fit.support.annotation.WithMockCustom;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(SecurityConfig.class)
+class AuthControllerTest {
+
+	private static final String ROLE_USER = "ROLE_USER";
+	private static final String API_AUTH_BASE_URL = "/api/v1/auth";
+	private static final String TEST_SUBJECT = "test@gmail.com";
+	private static final String TEST_ACCESS_TOKEN = "testAccessToken";
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	CustomOAuth2UserService customOAuth2UserService;
+
+	@MockitoBean
+	TokenProvider tokenProvider;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Test
+	@WithMockCustom(role = ROLE_USER)
+	@DisplayName("로그아웃 요청 테스트")
+	void userLogout() throws Exception {
+		//given
+		Claims claims = Mockito.mock(Claims.class);
+		Mockito.when(tokenProvider.resolveAccessToken(Mockito.any(HttpServletRequest.class)))
+			.thenReturn(TEST_ACCESS_TOKEN);
+		Mockito.when(tokenProvider.getClaimsByAccessToken(TEST_ACCESS_TOKEN))
+			.thenReturn(claims);
+		Mockito.when(claims.getSubject()).thenReturn(TEST_SUBJECT);
+		Mockito.when(claims.get(AUTHORITIES_KEY)).thenReturn(ROLE_USER);
+		Mockito.when(tokenProvider.validateAccessToken(TEST_ACCESS_TOKEN)).thenReturn(true);
+
+		//when
+		ResultActions actions = mockMvc.perform(
+			post(API_AUTH_BASE_URL + "/logout")
+				.header(AUTHORIZATION, BEARER_PREFIX + TEST_ACCESS_TOKEN));
+
+		//then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(header().exists(SET_COOKIE))
+			.andExpect(header().string(SET_COOKIE, containsString(REFRESH_TOKEN_COOKIE_NAME + "=;")))
+			.andExpect(header().string(SET_COOKIE, containsString("Path=/")))
+			.andExpect(header().string(SET_COOKIE, containsString("Max-Age=0")))
+			.andExpect(header().string(SET_COOKIE, containsString("HttpOnly")))
+			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Strict")))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("토큰 재발급 요청 테스트")
+	void reissueToken() throws Exception {
+		// given
+		String requestRefreshToken = "testRefreshToken";
+
+		Claims claims = Mockito.mock(Claims.class);
+		Mockito.when(tokenProvider.resolveAccessToken(Mockito.any(HttpServletRequest.class)))
+			.thenReturn(TEST_ACCESS_TOKEN);
+		Mockito.when(tokenProvider.getClaimsByAccessToken(TEST_ACCESS_TOKEN)).thenReturn(claims);
+		Mockito.when(claims.getSubject()).thenReturn(TEST_SUBJECT);
+		Mockito.when(claims.get(AUTHORITIES_KEY)).thenReturn(ROLE_USER);
+		when(tokenProvider.validateRefreshTokenWithAccessTokenInfo(ROLE_USER, TEST_SUBJECT,
+			requestRefreshToken)).thenReturn(true);
+
+		String newAccessToken = "newAccessToken";
+		Mockito.when(tokenProvider.createAccessToken(eq(TEST_SUBJECT), eq(ROLE_USER), any(Date.class)))
+			.thenReturn(newAccessToken);
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			post(API_AUTH_BASE_URL + "/reissue")
+				.header(AUTHORIZATION, BEARER_PREFIX + TEST_ACCESS_TOKEN)
+				.cookie(new Cookie(REFRESH_TOKEN_COOKIE_NAME, requestRefreshToken)));
+
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(header().string(AUTHORIZATION, newAccessToken))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("리다이렉트 토큰 쿠키 헤더 변환 요청 테스트")
+	void exchangeToken() throws Exception {
+		Cookie accessTokenCookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, TEST_ACCESS_TOKEN);
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			post(API_AUTH_BASE_URL + "/token-exchange")
+				.cookie(accessTokenCookie)
+		);
+
+		// then
+		actions
+			.andExpect(status().isOk())
+			.andExpect(header().string(AUTHORIZATION, BEARER_PREFIX + TEST_ACCESS_TOKEN))
+			.andExpect(header().string(SET_COOKIE, containsString(ACCESS_TOKEN_COOKIE_NAME + "=;")))
+			.andExpect(header().string(SET_COOKIE, containsString("Path=/")))
+			.andExpect(header().string(SET_COOKIE, containsString("Max-Age=0")))
+			.andExpect(header().string(SET_COOKIE, containsString("HttpOnly")))
+			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Strict")))
+			.andDo(print());
+	}
+}

--- a/src/test/java/eightplusone/bit/fit/domain/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/auth/jwt/TokenProviderTest.java
@@ -20,7 +20,7 @@ import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
 import eightplusone.bit.fit.domain.auth.service.CustomUserDetailsService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.entity.User;
-import eightplusone.bit.fit.support.UserFixture;
+import eightplusone.bit.fit.support.fixture.UserFixture;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -1,0 +1,60 @@
+package eightplusone.bit.fit.domain.user.service;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
+import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
+import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.domain.user.entity.User;
+import eightplusone.bit.fit.domain.user.repository.UserRepository;
+import eightplusone.bit.fit.support.fixture.UserFixture;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+	@Mock
+	UserRepository userRepository;
+
+	@Mock
+	RedisTokenService redisTokenService;
+
+	@Mock
+	OAuth2UnlinkService oAuth2UnlinkService;
+
+	@InjectMocks
+	UserService userService;
+
+	@Test
+	@DisplayName("회원 탈퇴를 한다")
+	void userDelete() {
+		//given
+		User user = UserFixture.USER_FIXTURE_1.createUser();
+		String provider = user.getProvider();
+
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+			new CustomUserDetails(user), null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())));
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+
+		Mockito.when(userRepository.findLoginUserByEmail(user.getEmail())).thenReturn(user);
+		Mockito.doNothing().when(oAuth2UnlinkService).unlink(provider);
+		//when
+		userService.delete();
+
+		//then
+		Mockito.verify(userRepository, Mockito.times(1)).delete(user);
+	}
+}

--- a/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
+++ b/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
@@ -55,31 +55,28 @@ class CookieUtilTest {
 	}
 
 	@Test
-	@DisplayName("찾는 이름의 쿠키가 요청에 없을 경우 null을_반환한다")
-	void findCookieByNameIfNotFoundThenReturnNull() {
+	@DisplayName("찾는 이름의 쿠키가 요청에 없을 경우 예외를 던진다")
+	void findCookieByNameIfNotFoundThenThrowException() {
 		// given
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		Cookie[] mockCookies = {new Cookie("differentCookie", COOKIE_VALUE)};
 		when(request.getCookies()).thenReturn(mockCookies);
 
-		// when
-		Cookie cookie = CookieUtil.findCookieByName(request, COOKIE_NAME);
-
-		// then
-		assertThat(cookie).isNull();
+		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
+			.isInstanceOf(NullPointerException.class)
+			.hasMessageContaining(COOKIE_NAME + " 쿠키를 찾을 수 없습니다.");
 	}
 
 	@Test
-	@DisplayName("요청된 쿠키가 없는 경우 null을_반환한다(")
-	void findCookieIfNullThenReturnNull() {
+	@DisplayName("요청된 쿠키가 없는 경우 예외를 던진다")
+	void findCookieIfNullThenThrowException() {
 		//given
 		HttpServletRequest request = mock(HttpServletRequest.class);
 		when(request.getCookies()).thenReturn(null);
 
-		//when
-		Cookie cookie = CookieUtil.findCookieByName(request, COOKIE_NAME);
-
-		//then
-		assertThat(cookie).isNull();
+		// when & then
+		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
+			.isInstanceOf(NullPointerException.class)
+			.hasMessageContaining(COOKIE_NAME + " 쿠키를 찾을 수 없습니다.");
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/support/annotation/WithMockCustom.java
+++ b/src/test/java/eightplusone/bit/fit/support/annotation/WithMockCustom.java
@@ -1,0 +1,21 @@
+package eightplusone.bit.fit.support.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import eightplusone.bit.fit.support.security.MockCustomUserSecurityContextFactory;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithSecurityContext(factory = MockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustom {
+	long id() default 1L;
+
+	String role();
+}

--- a/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
@@ -6,15 +6,17 @@ import lombok.Getter;
 
 @Getter
 public enum UserFixture {
-	USER_FIXTURE_1("test@gmail.com", "홍길동", Role.USER),
-	USER_FIXTURE_2("test2@gmail.com", "존도", Role.USER),
-	USER_FIXTURE_3("test3@gmail.com", "제인도", Role.USER);
+	USER_FIXTURE_1("google_test1", "test@gmail.com", "홍길동", Role.USER),
+	USER_FIXTURE_2("google_test2", "test2@gmail.com", "존도", Role.USER),
+	USER_FIXTURE_3("google_test3", "test3@gmail.com", "제인도", Role.USER);
 
+	private final String provider;
 	private final String email;
 	private final String name;
 	private final Role role;
 
-	UserFixture(String email, String name, Role role) {
+	UserFixture(String provider, String email, String name, Role role) {
+		this.provider = provider;
 		this.email = email;
 		this.name = name;
 		this.role = role;
@@ -22,6 +24,7 @@ public enum UserFixture {
 
 	public User createUser() {
 		return User.builder()
+			.provider(provider)
 			.email(email)
 			.name(name)
 			.role(role)

--- a/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
@@ -1,4 +1,4 @@
-package eightplusone.bit.fit.support;
+package eightplusone.bit.fit.support.fixture;
 
 import eightplusone.bit.fit.domain.auth.enums.Role;
 import eightplusone.bit.fit.domain.user.entity.User;

--- a/src/test/java/eightplusone/bit/fit/support/security/MockCustomUserSecurityContextFactory.java
+++ b/src/test/java/eightplusone/bit/fit/support/security/MockCustomUserSecurityContextFactory.java
@@ -1,0 +1,29 @@
+package eightplusone.bit.fit.support.security;
+
+import java.util.List;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
+import eightplusone.bit.fit.domain.user.entity.User;
+import eightplusone.bit.fit.support.annotation.WithMockCustom;
+import eightplusone.bit.fit.support.fixture.UserFixture;
+
+public class MockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustom> {
+
+	@Override
+	public SecurityContext createSecurityContext(WithMockCustom customUser) {
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		User mockUser = UserFixture.USER_FIXTURE_1.createUser();
+
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+			new CustomUserDetails(mockUser), null, List.of(new SimpleGrantedAuthority(customUser.role())));
+		context.setAuthentication(authentication);
+
+		return context;
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#4 ](이슈 링크)


### 변경 사항
1. 소셜로그인 중 다른 소셜로그인과 이메일 중복이 발생할 경우 쿼리파라미터로 에러를 전송하는 기능을 구현
2. 소셜로그인 성공시 302 리다이렉트로 전송되는 쿠키의 토큰을 헤더로 변경하는 기능을 구현
3. 토큰 재발급 기능, 로그아웃 기능을 구현
4. 회원탈퇴 + 소셜로그인 연결끊기 기능을 구현
5. Security 에러 핸들러를 구현

### 테스트 결과

### 1. 소셜로그인 중 다른 소셜로그인과 이메일 중복이 발생할 경우 쿼리파라미터로 에러를 전송하는 기능을 구현 테스트
![스크린샷 2025-03-07 오전 10 59 09](https://github.com/user-attachments/assets/5efb1b00-1c25-4117-9994-93f92ad0ef0f)
- React로 중복 회원가입을 발생시키며 테스트를 진행했습니다.

<br>

### 2. 소셜로그인 성공시 302 리다이렉트로 전송되는 쿠키의 토큰을 헤더로 변경하는 기능 구현 테스트
- 리다이렉트 쿠키 접근에 어려움이 있어, Swagger를 잠시 사용해서 테스트를 진행했습니다.

<br>

### 3. 토큰 재발급 기능, 로그아웃 기능 구현 테스트
<img width="678" alt="스크린샷 2025-03-07 오후 10 18 18" src="https://github.com/user-attachments/assets/e07d0c28-1ccb-4dfd-ad73-5352991668ac" />
- 2번 항목을 포함한 API TEST 코드와 함께 PostMan을 이용한 API 테스트도 진행하였습니다.

<br>

### 4. 회원탈퇴 + 소셜로그인 연결끊기 기능 구현 테스트
<img width="387" alt="스크린샷 2025-03-07 오후 10 21 37" src="https://github.com/user-attachments/assets/6cdb1be1-7aad-412e-b7e8-17d7b48ae9ab" />

![스크린샷 2025-03-07 오후 5 44 16](https://github.com/user-attachments/assets/7fa4027c-7bda-4422-a1d0-16b037289a5d)


<img width="510" alt="스크린샷 2025-03-07 오후 10 22 48" src="https://github.com/user-attachments/assets/36c5c5a7-6be1-4f35-95f4-d1d0a5d69e1a" />

- API 테스트는 PostMan을 이용하여 회원 탈퇴와 소셜 로그인 연결끊기가 동시에 진행되는지 확인했습니다. (위의 이미지는 FIT 연결이 사라진 모습입니다.)
