### PR TITLE
[#20] 음성 스트링밍 인증 기능

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -63,10 +63,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
+		String upgradeHeader = request.getHeader("Upgrade");
 		return Arrays.stream(ApiEndpoint.values())
 			.filter(endpoint -> endpoint.name().startsWith("PUBLIC_"))
 			.flatMap(endpoint -> Arrays.stream(endpoint.getPaths()))
 			.map(path -> path.replace("**", ".*"))
-			.anyMatch(requestUri::matches);
+			.anyMatch(requestUri::matches)
+			|| (upgradeHeader != null && upgradeHeader.equalsIgnoreCase("websocket"));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/AudioWebSocketConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/AudioWebSocketConfig.java
@@ -7,12 +7,18 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.domain.streaming.RoomManager;
 import eightplusone.bit.fit.global.websocket.CallHandler;
+import lombok.RequiredArgsConstructor;
 
 @EnableWebSocket
 @Configuration
+@RequiredArgsConstructor
 public class AudioWebSocketConfig implements WebSocketConfigurer {
+
+	private final TokenProvider tokenProvider;
+
 	@Bean
 	public RoomManager roomManager() {
 		return new RoomManager();
@@ -20,7 +26,7 @@ public class AudioWebSocketConfig implements WebSocketConfigurer {
 
 	@Bean
 	public CallHandler callHandler(RoomManager roomManager) {
-		return new CallHandler(roomManager);
+		return new CallHandler(roomManager, tokenProvider);
 	}
 
 	@Bean

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -11,6 +11,7 @@ public enum ApiEndpoint {
 		"/swagger-ui/**",
 		"/actuator/**",
 		"/v3/**",
+		"/call"
 	}),
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
@@ -1,5 +1,8 @@
 package eightplusone.bit.fit.global.websocket;
 
+import static eightplusone.bit.fit.global.constants.TokenConstant.*;
+import static org.springframework.http.HttpHeaders.*;
+
 import java.io.IOException;
 
 import org.kurento.client.IceCandidate;
@@ -11,8 +14,10 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
+import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.domain.streaming.Room;
 import eightplusone.bit.fit.domain.streaming.RoomManager;
+import io.jsonwebtoken.Claims;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -20,9 +25,11 @@ public class CallHandler extends TextWebSocketHandler {
 	private static final Gson gson = new Gson();
 
 	private final RoomManager roomManager;
+	private final TokenProvider tokenProvider;
 
-	public CallHandler(RoomManager roomManager) {
+	public CallHandler(RoomManager roomManager, TokenProvider tokenProvider) {
 		this.roomManager = roomManager;
+		this.tokenProvider = tokenProvider;
 	}
 
 	@Override
@@ -30,21 +37,48 @@ public class CallHandler extends TextWebSocketHandler {
 		JsonObject jsonMessage = gson.fromJson(message.getPayload(), JsonObject.class);
 		log.info("Incoming message from session '{}': {}", session.getId(), jsonMessage);
 
+		String userId = (String)session.getAttributes().get("userId");
+
+		if (jsonMessage.get("id").getAsString().equals(AUTHORIZATION)) {
+			String accessToken = jsonMessage.get("accessToken").getAsString().substring(BEARER_PREFIX.length());
+
+			if (tokenProvider.validateAccessToken(accessToken)) {
+				Claims claims = tokenProvider.getClaimsByAccessToken(accessToken);
+				session.getAttributes().put("userId", claims.getSubject());
+				sendResponse(session, AUTHORIZATION, "success");
+				log.info("User '{}' has been authenticated and stored for streaming access.", claims.getSubject());
+			} else {
+				sendError(session, "Invalid access accessToken");
+				session.close();
+			}
+			return;
+		}
+
+		if (userId == null) {
+			sendError(session, "Unauthorized access - userId missing");
+			session.close();
+			return;
+		}
+
 		String roomName = jsonMessage.get("room").getAsString();
 		Room room = roomManager.getRoom(roomName);
 		String messageId = jsonMessage.has("id") ? jsonMessage.get("id").getAsString() : "";
 
 		switch (messageId) {
 			case "presenter":
+				log.info("User '{}' attempting to present in room '{}'", userId, room.getName());
 				handlePresenter(session, room, jsonMessage);
 				break;
 			case "viewer":
+				log.info("User '{}' attempting to join as viewer in room '{}'", userId, room.getName());
 				handleViewer(session, room, jsonMessage);
 				break;
 			case "onIceCandidate":
+				log.info("User '{}' sending ICE candidate in room '{}'", userId, room.getName());
 				handleIceCandidate(session, room, jsonMessage);
 				break;
 			case "stop":
+				log.info("User '{}' stopping session in room '{}'", userId, room.getName());
 				handleStop(session, room);
 				break;
 			default:


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#20 ](https://github.com/FiT-8-plus-1-BiT/backend/issues/20)

### 변경 사항
- 토큰 기반 음성 스트리밍 인증 기능
- jwt 검증 필터 우회 조건 수정


### 테스트 결과
![스크린샷 2025-03-10 오후 1 10 04](https://github.com/user-attachments/assets/5d658e9a-972f-4de6-b326-2f80b1dbf282)
강연/청취 방 입장 시 권한 체크

![스크린샷 2025-03-10 오후 1 10 18](https://github.com/user-attachments/assets/7764ff66-4203-45a9-bead-8c1053f2e297)
권한이 유효한 유저라면 강연/청취 가능

![스크린샷 2025-03-10 오후 1 11 19](https://github.com/user-attachments/assets/34be2760-6ce9-4645-9676-b6ee7b7dc0bd)
토큰 인증을 하지 않은 경우 에러 (권한이 없는 경우)

### 추가 사항
실시간 채팅, 음성스트리밍의 websocket 방식 차이가 존재하기 때문에 확실히 분리하고 싶었습니다.
따라서 음성 스트리밍은 websocket handshake 이후 메세지 기반으로 토큰을 검증하고 인증하도록 구현했습니다.

일부 커밋메세지에 이슈를 잘 못 작성 했습니다. 신경쓰도록 하겠습니다 !


테스트에 사용한 소셜 로그인 + 음성스트리밍 jwt 부분이 추가된 React 코드 입니다.
[streaming_test.zip](https://github.com/user-attachments/files/19155484/streaming_test.zip)



