### PR TITLE
[#7] 실시간 혼잡도 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     // test
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+    //swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/eightplusone/bit/fit/FitApplication.java
+++ b/src/main/java/eightplusone/bit/fit/FitApplication.java
@@ -2,8 +2,10 @@ package eightplusone.bit.fit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class FitApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -63,6 +63,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
+		String requestUrl = request.getRequestURL().toString();
+		if (requestUri.startsWith("/ws-room") || requestUri.startsWith("/sub/session") || requestUrl.startsWith(
+			"https://jiangxy.github.io")) { // TODO : 마지막 조건문 삭제
+			return true;
+		} // 혼잡도 관련 -> 토큰 인증 X
 		return Arrays.stream(ApiEndpoint.values())
 			.filter(endpoint -> endpoint.name().startsWith("PUBLIC_"))
 			.flatMap(endpoint -> Arrays.stream(endpoint.getPaths()))

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -3,6 +3,7 @@ package eightplusone.bit.fit.domain.session.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.service.SessionService;
@@ -17,14 +18,14 @@ public class SessionController {
 
 	// TODO : 로그인 구현 후 수정
 	@PostMapping("/checkin")
-	public ResponseEntity<String> checkIn() {
-		sessionService.checkIn(1L); // 임시
+	public ResponseEntity<String> checkIn(@RequestParam("userId") Long userId) {
+		sessionService.checkIn(userId); // 임시
 		return ResponseEntity.ok("체크인 완료 했습니다.");
 	}
 
 	@PostMapping("/checkout")
-	public ResponseEntity<String> checkOut() {
-		sessionService.checkOut(1L); // 임시
+	public ResponseEntity<String> checkOut(@RequestParam Long userId) {
+		sessionService.checkOut(userId); // 임시
 		return ResponseEntity.ok("체크아웃 완료 했습니다.");
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -1,0 +1,30 @@
+package eightplusone.bit.fit.domain.session.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.session.service.SessionService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/room")
+@RequiredArgsConstructor
+public class SessionController {
+
+	private final SessionService sessionService;
+
+	// TODO : 로그인 구현 후 수정
+	@PostMapping("/checkin")
+	public ResponseEntity<String> checkIn() {
+		sessionService.checkIn(1L); // 임시
+		return ResponseEntity.ok("체크인 완료 했습니다.");
+	}
+
+	@PostMapping("/checkout")
+	public ResponseEntity<String> checkOut() {
+		sessionService.checkOut(1L); // 임시
+		return ResponseEntity.ok("체크아웃 완료 했습니다.");
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -9,7 +9,7 @@ import eightplusone.bit.fit.domain.session.service.SessionService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/room")
+@RequestMapping("/api/v1/enter")
 @RequiredArgsConstructor
 public class SessionController {
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -18,7 +18,7 @@ public class SessionWebSocketController {
 	private final SimpMessagingTemplate messagingTemplate;
 	private final SessionService sessionService;
 
-	@Scheduled(fixedRate = 10000)
+	@Scheduled(fixedRate = 30000)
 	public void broadcastSessionUpdate() {
 		Map<Long, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
 		log.info("send congestion data : {}", sessionData.toString());

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -2,7 +2,6 @@ package eightplusone.bit.fit.domain.session.controller;
 
 import java.util.Map;
 
-import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,11 +17,6 @@ public class SessionWebSocketController {
 
 	private final SimpMessagingTemplate messagingTemplate;
 	private final SessionService sessionService;
-
-	@MessageMapping("/session")
-	public void sendRoomUpdate(Map<String, Object> roomData) {
-		messagingTemplate.convertAndSend("/sub/session", roomData);
-	}
 
 	@Scheduled(fixedRate = 10000)
 	public void broadcastSessionUpdate() {

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -5,12 +5,14 @@ import java.util.Map;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.service.SessionService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequestMapping("/api/v1/congestion")
 @RequiredArgsConstructor
 public class SessionWebSocketController {
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -8,9 +8,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.service.SessionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class SessionWebSocketController {
 
 	private final SimpMessagingTemplate messagingTemplate;
@@ -19,7 +21,7 @@ public class SessionWebSocketController {
 	@Scheduled(fixedRate = 10000)
 	public void broadcastSessionUpdate() {
 		Map<Long, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
-		System.out.println("업데이트 전송" + sessionData);
-		messagingTemplate.convertAndSend("/sub/session", sessionData);
+		log.info("send congestion data : {}", sessionData.toString());
+		messagingTemplate.convertAndSend("/sub/ws-room", sessionData);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -1,0 +1,30 @@
+package eightplusone.bit.fit.domain.session.controller;
+
+import java.util.Map;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.session.service.SessionService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class SessionWebSocketController {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final SessionService sessionService;
+
+	@MessageMapping("/session")
+	public void sendRoomUpdate(Map<String, Object> roomData) {
+		messagingTemplate.convertAndSend("/sub/session", roomData);
+	}
+
+	@Scheduled(fixedRate = 10000)
+	public void broadcastSessionUpdate() {
+		Map<Long, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
+		messagingTemplate.convertAndSend("/sub/session", sessionData);
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -4,14 +4,12 @@ import java.util.Map;
 
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.service.SessionService;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/v1/congestion")
 @RequiredArgsConstructor
 public class SessionWebSocketController {
 
@@ -21,6 +19,7 @@ public class SessionWebSocketController {
 	@Scheduled(fixedRate = 10000)
 	public void broadcastSessionUpdate() {
 		Map<Long, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
+		System.out.println("업데이트 전송" + sessionData);
 		messagingTemplate.convertAndSend("/sub/session", sessionData);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -7,10 +7,12 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Entity
 @Getter
+@Table(name = "sessions")
 public class Session {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -7,11 +7,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Session {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,4 +30,7 @@ public class Session {
 
 	@Column(nullable = false)
 	private LocalDateTime endTime;
+
+	@Column(nullable = false)
+	private Integer standardCount;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -1,0 +1,34 @@
+package eightplusone.bit.fit.domain.session.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Session {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long sessionId;
+
+	@Column(nullable = false, length = 50)
+	private String title;
+
+	@Column(nullable = false, length = 200)
+	private String sessionImage;
+
+	@Column(nullable = false, length = 200)
+	private String summary;
+
+	@Column(nullable = false)
+	private LocalDateTime startTime;
+
+	@Column(nullable = false)
+	private LocalDateTime endTime;
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/enums/CongestionLevel.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/enums/CongestionLevel.java
@@ -1,0 +1,26 @@
+package eightplusone.bit.fit.domain.session.entity.enums;
+
+import java.util.Arrays;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CongestionLevel {
+	RELAXED("여유", 0, 50),
+	MODERATE("적정", 50, 80),
+	CROWDED("혼잡", 80, Integer.MAX_VALUE);
+
+	private final String label;
+	private final int min;
+	private final int max;
+
+	public static String fromPercent(double percent) {
+		return Arrays.stream(values())
+			.filter(level -> percent >= level.min && percent < level.max)
+			.findFirst()
+			.map(CongestionLevel::getLabel)
+			.orElseThrow(() -> new IllegalArgumentException("오류 발생"));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,0 +1,8 @@
+package eightplusone.bit.fit.domain.session.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+
+public interface SessionRepository extends JpaRepository<Session, Long> {
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -1,0 +1,30 @@
+package eightplusone.bit.fit.domain.session.service;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
+	// 체크인 시 레디스에 저장
+	public void checkIn(Long userId) {
+		redisTemplate.opsForSet().add("userId", userId);
+	}
+
+	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
+	// 체크아웃 시 레디스에서 삭제
+	public void checkOut(Long userId) {
+		redisTemplate.opsForSet().remove("userId", userId);
+	}
+
+	private String getCongestionLevel(Long currentCount, Integer maxCapacity) {
+
+		return "";
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -1,5 +1,9 @@
 package eightplusone.bit.fit.domain.session.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -28,7 +32,20 @@ public class SessionService {
 		redisTemplate.opsForHash().delete("session_user", userId);
 	}
 
-	public double getCongestionPercent(Long sessionId) {
+	public Map<Long, Map<String, Object>> getUpdatedSessionData() {
+		List<Session> sessions = sessionRepository.findAll();
+
+		return sessions.stream()
+			.collect(Collectors.toMap(
+				Session::getSessionId,  // 세션 ID를 Key로 사용
+				session -> Map.of(
+					"percent", getCongestionPercent(session.getSessionId()),
+					"level", getCongestionLevel(getCongestionPercent(session.getSessionId()))
+				)
+			));
+	}
+
+	private double getCongestionPercent(Long sessionId) {
 		Session session = sessionRepository.findById(sessionId)
 			.orElseThrow(() -> new EntityNotFoundException(sessionId + "에 해당하는 세션을 찾을 수 없습니다."));
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -38,7 +38,7 @@ public class SessionService {
 	// 혼잡도 전송
 	public Map<Long, Map<String, Object>> getUpdatedSessionData() {
 		List<Session> sessions = sessionRepository.findAll();
-		HashOperations<String, Long, String> hashOps = redisTemplate.opsForHash();
+		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
 		return sessions.stream()
 			.collect(Collectors.toMap(
@@ -47,7 +47,7 @@ public class SessionService {
 					double percent = getCongestionPercent(session.getSessionId());
 					String level = getCongestionLevel(percent);
 
-					hashOps.put(SESSION_CONGESTION_KEY, session.getSessionId(), level);
+					hashOps.put(SESSION_CONGESTION_KEY, session.getSessionId().toString(), level);
 
 					return Map.of("percent", percent, "level", level);
 				}
@@ -77,7 +77,7 @@ public class SessionService {
 
 	// 혼잡도 변경 시 -> 스트리밍쪽에서 설정
 	public void updateAndBroadcastIfChanged(Long sessionId) {
-		HashOperations<String, Long, String> hashOps = redisTemplate.opsForHash();
+		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
 		double percent = getCongestionPercent(sessionId);
 		String newLevel = getCongestionLevel(percent);
@@ -85,7 +85,7 @@ public class SessionService {
 		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionId);
 
 		if (!newLevel.equals(previousLevel)) {
-			hashOps.put(SESSION_CONGESTION_KEY, sessionId, newLevel);
+			hashOps.put(SESSION_CONGESTION_KEY, sessionId.toString(), newLevel);
 			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
 				"sessionId", sessionId,
 				"percent", percent,

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -23,17 +23,18 @@ public class SessionService {
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
 	public void checkIn(Long userId) {
-		redisTemplate.opsForHash().put("session_user", userId, "null");
+		redisTemplate.opsForHash().put("session_user", String.valueOf(userId), "null");
 	}
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크아웃 시 레디스에서 삭제
 	public void checkOut(Long userId) {
-		redisTemplate.opsForHash().delete("session_user", userId);
+		redisTemplate.opsForHash().delete("session_user", String.valueOf(userId));
 	}
 
 	public Map<Long, Map<String, Object>> getUpdatedSessionData() {
 		List<Session> sessions = sessionRepository.findAll();
+		System.out.println(sessions.get(0).getSessionId());
 
 		return sessions.stream()
 			.collect(Collectors.toMap(
@@ -53,7 +54,7 @@ public class SessionService {
 			.entries("session_user")
 			.values()
 			.stream()
-			.filter(sessionId::equals)
+			.filter(value -> sessionId.toString().equals(value.toString()))
 			.count();
 
 		Integer standardCnt = session.getStandardCount();

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -19,40 +20,47 @@ public class SessionService {
 
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final SessionRepository sessionRepository;
+	private final String SESSION_CONGESTION_KEY = "session_congestion";
+	private final String SESSION_USER_KEY = "session_user";
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
 	public void checkIn(Long userId) {
-		redisTemplate.opsForHash().put("session_user", String.valueOf(userId), "null");
+		redisTemplate.opsForHash().put(SESSION_USER_KEY, String.valueOf(userId), "null");
 	}
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크아웃 시 레디스에서 삭제
 	public void checkOut(Long userId) {
-		redisTemplate.opsForHash().delete("session_user", String.valueOf(userId));
+		redisTemplate.opsForHash().delete(SESSION_USER_KEY, String.valueOf(userId));
 	}
 
+	// 혼잡도 전송
 	public Map<Long, Map<String, Object>> getUpdatedSessionData() {
 		List<Session> sessions = sessionRepository.findAll();
-		System.out.println(sessions.get(0).getSessionId());
+		HashOperations<String, Long, String> hashOps = redisTemplate.opsForHash();
 
 		return sessions.stream()
 			.collect(Collectors.toMap(
-				Session::getSessionId,  // 세션 ID를 Key로 사용
-				session -> Map.of(
-					"percent", getCongestionPercent(session.getSessionId()),
-					"level", getCongestionLevel(getCongestionPercent(session.getSessionId()))
-				)
+				Session::getSessionId,
+				session -> {
+					double percent = getCongestionPercent(session.getSessionId());
+					String level = getCongestionLevel(percent);
+
+					hashOps.put(SESSION_CONGESTION_KEY, session.getSessionId(), level);
+
+					return Map.of("percent", percent, "level", level);
+				}
 			));
 	}
 
+	// 혼잡도 퍼센트
 	private double getCongestionPercent(Long sessionId) {
 		Session session = sessionRepository.findById(sessionId)
 			.orElseThrow(() -> new EntityNotFoundException(sessionId + "에 해당하는 세션을 찾을 수 없습니다."));
 
 		long connectedUsers = redisTemplate.opsForHash()
-			.entries("session_user")
-			.values()
+			.values(SESSION_USER_KEY)
 			.stream()
 			.filter(value -> sessionId.toString().equals(value.toString()))
 			.count();
@@ -62,7 +70,27 @@ public class SessionService {
 		return ((double)connectedUsers / standardCnt) * 100;
 	}
 
-	public String getCongestionLevel(double percent) {
+	// 혼잡도 레벨
+	private String getCongestionLevel(double percent) {
 		return CongestionLevel.fromPercent(percent);
+	}
+
+	// 혼잡도 변경 시 -> 스트리밍쪽에서 설정
+	public void updateAndBroadcastIfChanged(Long sessionId) {
+		HashOperations<String, Long, String> hashOps = redisTemplate.opsForHash();
+
+		double percent = getCongestionPercent(sessionId);
+		String newLevel = getCongestionLevel(percent);
+
+		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionId);
+
+		if (!newLevel.equals(previousLevel)) {
+			hashOps.put(SESSION_CONGESTION_KEY, sessionId, newLevel);
+			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
+				"sessionId", sessionId,
+				"percent", percent,
+				"level", newLevel
+			));
+		}
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -3,6 +3,10 @@ package eightplusone.bit.fit.domain.session.service;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -10,21 +14,37 @@ import lombok.RequiredArgsConstructor;
 public class SessionService {
 
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final SessionRepository sessionRepository;
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
 	public void checkIn(Long userId) {
-		redisTemplate.opsForSet().add("userId", userId);
+		redisTemplate.opsForHash().put("session_user", userId, "null");
 	}
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크아웃 시 레디스에서 삭제
 	public void checkOut(Long userId) {
-		redisTemplate.opsForSet().remove("userId", userId);
+		redisTemplate.opsForHash().delete("session_user", userId);
 	}
 
-	private String getCongestionLevel(Long currentCount, Integer maxCapacity) {
+	public double getCongestionPercent(Long sessionId) {
+		Session session = sessionRepository.findById(sessionId)
+			.orElseThrow(() -> new EntityNotFoundException(sessionId + "에 해당하는 세션을 찾을 수 없습니다."));
 
-		return "";
+		long connectedUsers = redisTemplate.opsForHash()
+			.entries("session_user")
+			.values()
+			.stream()
+			.filter(sessionId::equals)
+			.count();
+
+		Integer standardCnt = session.getStandardCount();
+
+		return ((double)connectedUsers / standardCnt) * 100;
+	}
+
+	public String getCongestionLevel(double percent) {
+		return CongestionLevel.fromPercent(percent);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/RedisConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/RedisConfig.java
@@ -21,6 +21,9 @@ public class RedisConfig {
 		template.setConnectionFactory(redisConnectionFactory());
 		template.setKeySerializer(new StringRedisSerializer());
 		template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		template.setHashKeySerializer(new StringRedisSerializer());
+		template.setHashValueSerializer(new StringRedisSerializer());
+		template.afterPropertiesSet();
 		return template;
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import static eightplusone.bit.fit.global.constants.CorsConstant.*;
 import static eightplusone.bit.fit.global.enums.ApiEndpoint.*;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -55,7 +56,8 @@ public class SecurityConfig {
 		http
 			.cors(corsCustomizer -> corsCustomizer.configurationSource(request -> {
 				CorsConfiguration configuration = new CorsConfiguration();
-				configuration.setAllowedOrigins(Collections.singletonList(allowedOrigins));
+				configuration.setAllowedOrigins(
+					List.of("https://jiangxy.github.io", "http://localhost:3000")); // TODO : 혼잡도 구현 끝날 경우 원본으로 되돌리기
 				configuration.setAllowedMethods(ALLOWED_METHODS);
 				configuration.setAllowCredentials(ALLOWED_CREDENTIALS);
 				configuration.setAllowedHeaders(ALLOWED_HEADERS);

--- a/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
@@ -19,5 +19,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws-chat").setAllowedOrigins("*").withSockJS();
+		registry.addEndpoint("/ws-room").setAllowedOrigins("*").withSockJS();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
@@ -19,6 +19,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
 		registry.addEndpoint("/ws-chat").setAllowedOrigins("*").withSockJS();
-		registry.addEndpoint("/ws-room").setAllowedOrigins("*").withSockJS();
+		registry.addEndpoint("/ws-room").setAllowedOriginPatterns("*");
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -102,7 +102,7 @@ class SessionServiceTest {
 		sessionService.updateAndBroadcastIfChanged(sessionId);
 
 		// Then
-		verify(hashOperations).put("session_congestion", sessionId, newLevel);
+		verify(hashOperations).put("session_congestion", sessionId.toString(), newLevel);
 		verify(redisTemplate).convertAndSend(eq("/sub/ws-room"), argThat(message -> {
 			Map<String, Object> msg = (Map<String, Object>)message;
 			return msg.get("sessionId").equals(sessionId) &&

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -48,7 +48,7 @@ class SessionServiceTest {
 		sessionService.checkIn(userId);
 
 		// Then
-		verify(hashOperations).put("session_user", userId, "null");
+		verify(hashOperations).put("session_user", userId.toString(), "null");
 	}
 
 	@Test
@@ -60,25 +60,26 @@ class SessionServiceTest {
 		sessionService.checkOut(userId);
 
 		// Then
-		verify(hashOperations).delete("session_user", userId);
+		verify(hashOperations).delete("session_user", userId.toString());
 	}
 
 	@Test
 	void getUpdatedSessionData() {
-		// Given
 		Session session = new Session();
 		setField(session, "sessionId", 123L);
 		setField(session, "standardCount", 10);
 
 		when(sessionRepository.findAll()).thenReturn(List.of(session));
 		when(sessionRepository.findById(123L)).thenReturn(Optional.of(session));
-		when(hashOperations.entries("session_user")).thenReturn(Map.of(1L, 123L, 2L, 123L)); // 2명이 같은 세션에 접속 중
 
-		// When
+		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123")); // 2명 접속
+
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+
 		Map<Long, Map<String, Object>> result = sessionService.getUpdatedSessionData();
 
-		// Then
 		assertThat(result).containsKey(123L);
-		assertThat(result.get(123L)).containsEntry("percent", 20.0); // 2/10 * 100 = 20%
+		assertThat(result.get(123L)).containsEntry("percent", 20.0);
 	}
+
 }

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -82,4 +82,32 @@ class SessionServiceTest {
 		assertThat(result.get(123L)).containsEntry("percent", 20.0);
 	}
 
+	@Test
+	void updateAndBroadcastIfChanged() {
+		// Given
+		Long sessionId = 123L;
+		double percent = 100.0;
+		String currentLevel = "여유"; // 기존 값
+		String newLevel = "혼잡"; // 예상값 (변경됨)
+		Session session = new Session();
+		setField(session, "sessionId", 123L);
+		setField(session, "standardCount", 5);
+
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+		when(hashOperations.get("session_congestion", sessionId)).thenReturn(currentLevel);
+		when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123", "123", "123", "123"));
+
+		// When
+		sessionService.updateAndBroadcastIfChanged(sessionId);
+
+		// Then
+		verify(hashOperations).put("session_congestion", sessionId, newLevel);
+		verify(redisTemplate).convertAndSend(eq("/sub/ws-room"), argThat(message -> {
+			Map<String, Object> msg = (Map<String, Object>)message;
+			return msg.get("sessionId").equals(sessionId) &&
+				msg.get("percent").equals(percent) &&
+				msg.get("level").equals(newLevel);
+		}));
+	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -1,0 +1,84 @@
+package eightplusone.bit.fit.domain.session.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+
+class SessionServiceTest {
+
+	@Mock
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Mock
+	private HashOperations<String, Object, Object> hashOperations;
+
+	@Mock
+	private SessionRepository sessionRepository;
+
+	@InjectMocks
+	private SessionService sessionService;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+	}
+
+	@Test
+	void checkIn() {
+		// Given
+		Long userId = 1L;
+
+		// When
+		sessionService.checkIn(userId);
+
+		// Then
+		verify(hashOperations).put("session_user", userId, "null");
+	}
+
+	@Test
+	void checkOut() {
+		// Given
+		Long userId = 1L;
+
+		// When
+		sessionService.checkOut(userId);
+
+		// Then
+		verify(hashOperations).delete("session_user", userId);
+	}
+
+	@Test
+	void getUpdatedSessionData() {
+		// Given
+		Session session = new Session();
+		setField(session, "sessionId", 123L);
+		setField(session, "standardCount", 10);
+
+		when(sessionRepository.findAll()).thenReturn(List.of(session));
+		when(sessionRepository.findById(123L)).thenReturn(Optional.of(session));
+		when(hashOperations.entries("session_user")).thenReturn(Map.of(1L, 123L, 2L, 123L)); // 2명이 같은 세션에 접속 중
+
+		// When
+		Map<Long, Map<String, Object>> result = sessionService.getUpdatedSessionData();
+
+		// Then
+		assertThat(result).containsKey(123L);
+		assertThat(result.get(123L)).containsEntry("percent", 20.0); // 2/10 * 100 = 20%
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed. #7 

### 변경 사항
1. 체크인과 체크아웃 구현 (추후 토큰으로 수정 예정)
2. 혼잡도 계산 및 websocket을 이용하여 전송

### 테스트 결과
1. WebSocket으로 실시간 혼잡도 전송
<img width="1913" alt="스크린샷 2025-03-10 오후 2 11 05" src="https://github.com/user-attachments/assets/79001957-94ec-4d06-8c23-b88c1a78c7d5" />
10초로 테스트한 결과

</br>
</br>

2. 테스트 코드
<img width="1694" alt="스크린샷 2025-03-10 오후 4 21 44" src="https://github.com/user-attachments/assets/3c3f80b8-b9f5-4cae-9422-1c7f974baea5" />


### 추가 사항
1. `SessionService.updateAndBroadcastIfChanged()`은 스트리밍쪽에서 사용하도록 작성하였고 일단 테스트코드로만 확인해봤습니다 .. ㅜㅜ

2. 혼잡도 같은 경우는 토큰이 없어도 볼 수 있어야 한다고 생각하여 해당 부분 수정하였고, 웹소켓 테스트용 url("https://jiangxy.github.io")을 임시로 추가했습니다.
- `SecurityConfig` 클래스에 setAllowedOrigins를 수정했는데 해당 주소가 있어야 웹소켓 테스트가 가능해서 임시로 추가해놨습니다. 추후 원본 코드로 돌려놓겠습니다
- `JwtAuthenticationFilter.shouldNotFilter` 클래스에 토큰 인증 없이 가능하도록 조건문으로 수정해놨습니다. 여기도 추후에 조건문에 있는 테스트용 url 삭제하겠습니다!