### PR TITLE
[#24] 음성 스트리밍 혼잡도 분석 기능 호출

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -1,9 +1,9 @@
 package eightplusone.bit.fit.domain.session.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.service.SessionService;
@@ -18,14 +18,14 @@ public class SessionController {
 
 	// TODO : 로그인 구현 후 수정
 	@PostMapping("/checkin")
-	public ResponseEntity<String> checkIn(@RequestParam("userId") Long userId) {
-		sessionService.checkIn(userId); // 임시
+	public ResponseEntity<String> checkIn() {
+		sessionService.checkIn(SecurityContextHolder.getContext().getAuthentication().getName());
 		return ResponseEntity.ok("체크인 완료 했습니다.");
 	}
 
 	@PostMapping("/checkout")
-	public ResponseEntity<String> checkOut(@RequestParam Long userId) {
-		sessionService.checkOut(userId); // 임시
+	public ResponseEntity<String> checkOut() {
+		sessionService.checkOut(SecurityContextHolder.getContext().getAuthentication().getName());
 		return ResponseEntity.ok("체크아웃 완료 했습니다.");
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -20,7 +20,7 @@ public class SessionWebSocketController {
 
 	@Scheduled(fixedRate = 30000)
 	public void broadcastSessionUpdate() {
-		Map<Long, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
+		Map<Integer, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
 		log.info("send congestion data : {}", sessionData.toString());
 		messagingTemplate.convertAndSend("/sub/ws-room", sessionData);
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -37,5 +37,5 @@ public class Session {
 	private Integer standardCount;
 
 	@Column(nullable = false)
-	private Integer number;
+	private Integer audioChannel;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -35,4 +35,7 @@ public class Session {
 
 	@Column(nullable = false)
 	private Integer standardCount;
+
+	@Column(nullable = false)
+	private Integer number;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,8 +1,11 @@
 package eightplusone.bit.fit.domain.session.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
+	Optional<Session> findByNumber(Integer number);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import eightplusone.bit.fit.domain.session.entity.Session;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
-	Optional<Session> findByNumber(Integer number);
+	Optional<Session> findByAudioChannel(Integer audioChannel);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -42,12 +42,12 @@ public class SessionService {
 
 		return sessions.stream()
 			.collect(Collectors.toMap(
-				Session::getNumber,
+				Session::getAudioChannel,
 				session -> {
-					double percent = getCongestionPercent(session.getNumber());
+					double percent = getCongestionPercent(session.getAudioChannel());
 					String level = getCongestionLevel(percent);
 
-					hashOps.put(SESSION_CONGESTION_KEY, session.getNumber().toString(), level);
+					hashOps.put(SESSION_CONGESTION_KEY, session.getAudioChannel().toString(), level);
 
 					return Map.of("percent", percent, "level", level);
 				}
@@ -55,14 +55,14 @@ public class SessionService {
 	}
 
 	// 혼잡도 퍼센트
-	private double getCongestionPercent(Integer sessionNumber) {
-		Session session = sessionRepository.findByNumber(sessionNumber)
-			.orElseThrow(() -> new EntityNotFoundException(sessionNumber + "에 해당하는 세션을 찾을 수 없습니다."));
+	private double getCongestionPercent(Integer audioChannel) {
+		Session session = sessionRepository.findByAudioChannel(audioChannel)
+			.orElseThrow(() -> new EntityNotFoundException(audioChannel + "에 해당하는 세션을 찾을 수 없습니다."));
 
 		long connectedUsers = redisTemplate.opsForHash()
 			.values(SESSION_USER_KEY)
 			.stream()
-			.filter(value -> sessionNumber.toString().equals(value.toString()))
+			.filter(value -> audioChannel.toString().equals(value.toString()))
 			.count();
 
 		Integer standardCnt = session.getStandardCount();
@@ -76,18 +76,18 @@ public class SessionService {
 	}
 
 	// 혼잡도 변경 시 -> 스트리밍쪽에서 설정
-	public void updateAndBroadcastIfChanged(Integer sessionNumber) {
+	public void updateAndBroadcastIfChanged(Integer audioChannel) {
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
-		double percent = getCongestionPercent(sessionNumber);
+		double percent = getCongestionPercent(audioChannel);
 		String newLevel = getCongestionLevel(percent);
 
-		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionNumber);
+		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, audioChannel);
 
 		if (!newLevel.equals(previousLevel)) {
-			hashOps.put(SESSION_CONGESTION_KEY, sessionNumber.toString(), newLevel);
+			hashOps.put(SESSION_CONGESTION_KEY, audioChannel.toString(), newLevel);
 			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
-				"sessionId", sessionNumber,
+				"sessionId", audioChannel,
 				"percent", percent,
 				"level", newLevel
 			));

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -36,18 +36,18 @@ public class SessionService {
 	}
 
 	// 혼잡도 전송
-	public Map<Long, Map<String, Object>> getUpdatedSessionData() {
+	public Map<Integer, Map<String, Object>> getUpdatedSessionData() {
 		List<Session> sessions = sessionRepository.findAll();
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
 		return sessions.stream()
 			.collect(Collectors.toMap(
-				Session::getSessionId,
+				Session::getNumber,
 				session -> {
-					double percent = getCongestionPercent(session.getSessionId());
+					double percent = getCongestionPercent(session.getNumber());
 					String level = getCongestionLevel(percent);
 
-					hashOps.put(SESSION_CONGESTION_KEY, session.getSessionId().toString(), level);
+					hashOps.put(SESSION_CONGESTION_KEY, session.getNumber().toString(), level);
 
 					return Map.of("percent", percent, "level", level);
 				}
@@ -55,14 +55,14 @@ public class SessionService {
 	}
 
 	// 혼잡도 퍼센트
-	private double getCongestionPercent(Long sessionId) {
-		Session session = sessionRepository.findById(sessionId)
-			.orElseThrow(() -> new EntityNotFoundException(sessionId + "에 해당하는 세션을 찾을 수 없습니다."));
+	private double getCongestionPercent(Integer sessionNumber) {
+		Session session = sessionRepository.findByNumber(sessionNumber)
+			.orElseThrow(() -> new EntityNotFoundException(sessionNumber + "에 해당하는 세션을 찾을 수 없습니다."));
 
 		long connectedUsers = redisTemplate.opsForHash()
 			.values(SESSION_USER_KEY)
 			.stream()
-			.filter(value -> sessionId.toString().equals(value.toString()))
+			.filter(value -> sessionNumber.toString().equals(value.toString()))
 			.count();
 
 		Integer standardCnt = session.getStandardCount();
@@ -76,18 +76,18 @@ public class SessionService {
 	}
 
 	// 혼잡도 변경 시 -> 스트리밍쪽에서 설정
-	public void updateAndBroadcastIfChanged(Long sessionId) {
+	public void updateAndBroadcastIfChanged(Integer sessionNumber) {
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
-		double percent = getCongestionPercent(sessionId);
+		double percent = getCongestionPercent(sessionNumber);
 		String newLevel = getCongestionLevel(percent);
 
-		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionId);
+		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionNumber);
 
 		if (!newLevel.equals(previousLevel)) {
-			hashOps.put(SESSION_CONGESTION_KEY, sessionId.toString(), newLevel);
+			hashOps.put(SESSION_CONGESTION_KEY, sessionNumber.toString(), newLevel);
 			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
-				"sessionId", sessionId,
+				"sessionId", sessionNumber,
 				"percent", percent,
 				"level", newLevel
 			));

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -25,14 +25,14 @@ public class SessionService {
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
-	public void checkIn(Long userId) {
-		redisTemplate.opsForHash().put(SESSION_USER_KEY, String.valueOf(userId), "null");
+	public void checkIn(String email) {
+		redisTemplate.opsForHash().put(SESSION_USER_KEY, email, "null");
 	}
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크아웃 시 레디스에서 삭제
-	public void checkOut(Long userId) {
-		redisTemplate.opsForHash().delete(SESSION_USER_KEY, String.valueOf(userId));
+	public void checkOut(String email) {
+		redisTemplate.opsForHash().delete(SESSION_USER_KEY, email);
 	}
 
 	// 혼잡도 전송

--- a/src/main/java/eightplusone/bit/fit/domain/streaming/Room.java
+++ b/src/main/java/eightplusone/bit/fit/domain/streaming/Room.java
@@ -12,6 +12,7 @@ import org.kurento.client.Continuation;
 import org.kurento.client.MediaPipeline;
 import org.kurento.client.WebRtcEndpoint;
 
+import eightplusone.bit.fit.domain.session.service.SessionService;
 import eightplusone.bit.fit.global.websocket.UserSession;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -26,9 +27,12 @@ public class Room implements Closeable {
 	@Getter
 	private UserSession presenterUserSession; // 발표자 (1명)
 
-	public Room(String roomName, MediaPipeline pipeline) {
+	private final SessionService sessionService;
+
+	public Room(String roomName, MediaPipeline pipeline, SessionService sessionService) {
 		this.name = roomName;
 		this.pipeline = pipeline;
+		this.sessionService = sessionService;
 		log.info("ROOM {} has been created", roomName);
 	}
 
@@ -58,7 +62,7 @@ public class Room implements Closeable {
 		return false;
 	}
 
-	public synchronized boolean addViewer(UserSession viewer) {
+	public synchronized boolean addViewer(UserSession viewer, String roomName) {
 		if (this.presenterUserSession == null) {
 			return false; // 발표자가 있어야만 시청자가 참가 가능
 		}
@@ -79,14 +83,17 @@ public class Room implements Closeable {
 		log.info("Viewer {} connected to presenter in room {}", viewer.getSession().getId(), name);
 		viewers.put(viewer.getSession().getId(), viewer);
 		log.info("현재 viewer 수: {}", viewers.size());
+
+		sessionService.updateAndBroadcastIfChanged(Integer.valueOf(roomName));
 		return true;
 	}
 
-	public synchronized void removeViewer(String sessionId) {
+	public synchronized void removeViewer(String sessionId, String roomName) {
 		if (viewers.containsKey(sessionId)) {
 			viewers.remove(sessionId);
 			log.info("Viewer {} removed from room {}", sessionId, name);
 			log.info("현재 viewer 수: {}", viewers.size());
+			sessionService.updateAndBroadcastIfChanged(Integer.valueOf(roomName));
 		} else {
 			log.warn("Viewer {} not found in room {}", sessionId, name);
 		}

--- a/src/main/java/eightplusone/bit/fit/domain/streaming/RoomManager.java
+++ b/src/main/java/eightplusone/bit/fit/domain/streaming/RoomManager.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.kurento.client.KurentoClient;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import eightplusone.bit.fit.domain.session.service.SessionService;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -14,6 +15,9 @@ public class RoomManager {
 
 	@Autowired
 	private KurentoClient kurento;
+
+	@Autowired
+	private SessionService sessionService;
 
 	private final ConcurrentMap<String, Room> rooms = new ConcurrentHashMap<>();
 
@@ -23,7 +27,7 @@ public class RoomManager {
 
 		if (room == null) {
 			log.info("Room {} not found. Creating new room.", roomName);
-			room = new Room(roomName, kurento.createMediaPipeline());
+			room = new Room(roomName, kurento.createMediaPipeline(), sessionService);
 			rooms.put(roomName, room);
 		}
 

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -15,7 +15,9 @@ public enum ApiEndpoint {
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {
 		"/api/v1/auth/reissue",
-		"/api/v1/auth/token-exchange"
+		"/api/v1/auth/token-exchange",
+		"/api/v1/enter/checkin",
+		"/api/v1/enter/checkout"
 	}),
 
 	AUTHENTICATED_GET(HttpMethod.GET, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -17,15 +17,15 @@ public enum ApiEndpoint {
 	PUBLIC_POST(HttpMethod.POST, new String[] {
 		"/api/v1/auth/reissue",
 		"/api/v1/auth/token-exchange",
-		"/api/v1/enter/checkin",
-		"/api/v1/enter/checkout"
 	}),
 
 	AUTHENTICATED_GET(HttpMethod.GET, new String[] {
 	}),
 
 	AUTHENTICATED_POST(HttpMethod.POST, new String[] {
-		"/api/v1/auth/logout"
+		"/api/v1/auth/logout",
+		"/api/v1/enter/checkin",
+		"/api/v1/enter/checkout"
 	}),
 
 	AUTHENTICATED_PUT(HttpMethod.PUT, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/websocket/CallHandler.java
@@ -76,7 +76,7 @@ public class CallHandler extends TextWebSocketHandler {
 		}
 
 		UserSession viewer = new UserSession(session);
-		if (room.addViewer(viewer)) {
+		if (room.addViewer(viewer, room.getName())) {
 			String sdpOffer = jsonMessage.get("sdpOffer").getAsString();
 			String sdpAnswer = room.processViewerOffer(viewer, sdpOffer);
 			sendResponse(session, "viewerResponse", "accepted", "sdpAnswer", sdpAnswer);
@@ -108,7 +108,7 @@ public class CallHandler extends TextWebSocketHandler {
 			room.removePresenter();
 			roomManager.removeRoom(room.getName());
 		} else {
-			room.removeViewer(session.getId());
+			room.removeViewer(session.getId(), room.getName());
 		}
 		session.close();
 	}
@@ -123,7 +123,7 @@ public class CallHandler extends TextWebSocketHandler {
 				return;
 			}
 			log.info("Checking if {} is a viewer in room {}", session.getId(), room.getName());
-			room.removeViewer(session.getId());
+			room.removeViewer(session.getId(), room.getName());
 		}
 	}
 

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -66,46 +66,46 @@ class SessionServiceTest {
 	@Test
 	void getUpdatedSessionData() {
 		Session session = new Session();
-		setField(session, "sessionId", 123L);
+		setField(session, "number", 123);
 		setField(session, "standardCount", 10);
 
 		when(sessionRepository.findAll()).thenReturn(List.of(session));
-		when(sessionRepository.findById(123L)).thenReturn(Optional.of(session));
+		when(sessionRepository.findByNumber(123)).thenReturn(Optional.of(session));
 
 		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123")); // 2명 접속
 
 		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
 
-		Map<Long, Map<String, Object>> result = sessionService.getUpdatedSessionData();
+		Map<Integer, Map<String, Object>> result = sessionService.getUpdatedSessionData();
 
-		assertThat(result).containsKey(123L);
-		assertThat(result.get(123L)).containsEntry("percent", 20.0);
+		assertThat(result).containsKey(123);
+		assertThat(result.get(123)).containsEntry("percent", 20.0);
 	}
 
 	@Test
 	void updateAndBroadcastIfChanged() {
 		// Given
-		Long sessionId = 123L;
+		Integer number = 123;
 		double percent = 100.0;
 		String currentLevel = "여유"; // 기존 값
 		String newLevel = "혼잡"; // 예상값 (변경됨)
 		Session session = new Session();
-		setField(session, "sessionId", 123L);
+		setField(session, "number", 123);
 		setField(session, "standardCount", 5);
 
 		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
-		when(hashOperations.get("session_congestion", sessionId)).thenReturn(currentLevel);
-		when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+		when(hashOperations.get("session_congestion", number)).thenReturn(currentLevel);
+		when(sessionRepository.findByNumber(number)).thenReturn(Optional.of(session));
 		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123", "123", "123", "123"));
 
 		// When
-		sessionService.updateAndBroadcastIfChanged(sessionId);
+		sessionService.updateAndBroadcastIfChanged(number);
 
 		// Then
-		verify(hashOperations).put("session_congestion", sessionId.toString(), newLevel);
+		verify(hashOperations).put("session_congestion", number.toString(), newLevel);
 		verify(redisTemplate).convertAndSend(eq("/sub/ws-room"), argThat(message -> {
 			Map<String, Object> msg = (Map<String, Object>)message;
-			return msg.get("sessionId").equals(sessionId) &&
+			return msg.get("sessionId").equals(number) &&
 				msg.get("percent").equals(percent) &&
 				msg.get("level").equals(newLevel);
 		}));

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -66,11 +66,11 @@ class SessionServiceTest {
 	@Test
 	void getUpdatedSessionData() {
 		Session session = new Session();
-		setField(session, "number", 123);
+		setField(session, "audioChannel", 123);
 		setField(session, "standardCount", 10);
 
 		when(sessionRepository.findAll()).thenReturn(List.of(session));
-		when(sessionRepository.findByNumber(123)).thenReturn(Optional.of(session));
+		when(sessionRepository.findByAudioChannel(123)).thenReturn(Optional.of(session));
 
 		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123")); // 2명 접속
 
@@ -85,27 +85,27 @@ class SessionServiceTest {
 	@Test
 	void updateAndBroadcastIfChanged() {
 		// Given
-		Integer number = 123;
+		Integer audioChannel = 123;
 		double percent = 100.0;
 		String currentLevel = "여유"; // 기존 값
 		String newLevel = "혼잡"; // 예상값 (변경됨)
 		Session session = new Session();
-		setField(session, "number", 123);
+		setField(session, "audioChannel", 123);
 		setField(session, "standardCount", 5);
 
 		when(redisTemplate.opsForHash()).thenReturn(hashOperations);
-		when(hashOperations.get("session_congestion", number)).thenReturn(currentLevel);
-		when(sessionRepository.findByNumber(number)).thenReturn(Optional.of(session));
+		when(hashOperations.get("session_congestion", audioChannel)).thenReturn(currentLevel);
+		when(sessionRepository.findByAudioChannel(audioChannel)).thenReturn(Optional.of(session));
 		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123", "123", "123", "123"));
 
 		// When
-		sessionService.updateAndBroadcastIfChanged(number);
+		sessionService.updateAndBroadcastIfChanged(audioChannel);
 
 		// Then
-		verify(hashOperations).put("session_congestion", number.toString(), newLevel);
+		verify(hashOperations).put("session_congestion", audioChannel.toString(), newLevel);
 		verify(redisTemplate).convertAndSend(eq("/sub/ws-room"), argThat(message -> {
 			Map<String, Object> msg = (Map<String, Object>)message;
-			return msg.get("sessionId").equals(number) &&
+			return msg.get("sessionId").equals(audioChannel) &&
 				msg.get("percent").equals(percent) &&
 				msg.get("level").equals(newLevel);
 		}));

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -42,25 +42,25 @@ class SessionServiceTest {
 	@Test
 	void checkIn() {
 		// Given
-		Long userId = 1L;
+		String email = "test@gmail.com";
 
 		// When
-		sessionService.checkIn(userId);
+		sessionService.checkIn(email);
 
 		// Then
-		verify(hashOperations).put("session_user", userId.toString(), "null");
+		verify(hashOperations).put("session_user", email, "null");
 	}
 
 	@Test
 	void checkOut() {
 		// Given
-		Long userId = 1L;
+		String email = "test@gmail.com";
 
 		// When
-		sessionService.checkOut(userId);
+		sessionService.checkOut(email);
 
 		// Then
-		verify(hashOperations).delete("session_user", userId.toString());
+		verify(hashOperations).delete("session_user", email);
 	}
 
 	@Test


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#24](이슈 링크)


### 변경 사항
- 음성 스트리밍 청취자 입장 퇴장 시 updateAndBroadcastIfChanged 호출
- sessionService에서 사용되는 sessionId를 sessionNumber로 변경
- 체크인 시 시큐리티컨텍스트 홀더의 이메일 값 사용으로 변경

### 테스트 결과

SessionServiceTest
![스크린샷 2025-03-11 오후 2 20 00](https://github.com/user-attachments/assets/fd0e7fa0-3801-4e1e-b422-6a86ef51c1c1)

체크인 테스트
<img width="906" alt="스크린샷 2025-03-11 오후 2 29 58" src="https://github.com/user-attachments/assets/74269fd1-d130-4774-a79b-1e207d6f9ef8" />

스트리밍 테스트

사용한 임시 Sesstion insert 쿼리문
```sql
INSERT INTO fit.sessions (title, session_image, summary, start_time, end_time, standard_count, number) VALUES
('Session 1', 'image1.jpg', 'Summary 1', '2025-03-11 09:00:00', '2025-03-11 10:00:00', 10, 1),
('Session 2', 'image2.jpg', 'Summary 2', '2025-03-11 10:00:00', '2025-03-11 11:00:00', 10, 2),
('Session 3', 'image3.jpg', 'Summary 3', '2025-03-11 11:00:00', '2025-03-11 12:00:00', 10, 3),
('Session 4', 'image4.jpg', 'Summary 4', '2025-03-11 12:00:00', '2025-03-11 13:00:00', 10, 4),
('Session 5', 'image5.jpg', 'Summary 5', '2025-03-11 13:00:00', '2025-03-11 14:00:00', 10, 5),
('Session 6', 'image6.jpg', 'Summary 6', '2025-03-11 14:00:00', '2025-03-11 15:00:00', 10, 6),
('Session 7', 'image7.jpg', 'Summary 7', '2025-03-11 15:00:00', '2025-03-11 16:00:00', 10, 7),
('Session 8', 'image8.jpg', 'Summary 8', '2025-03-11 16:00:00', '2025-03-11 17:00:00', 10, 8),
('Session 9', 'image9.jpg', 'Summary 9', '2025-03-11 17:00:00', '2025-03-11 18:00:00', 10, 9),
('Session 10', 'image10.jpg', 'Summary 10', '2025-03-11 18:00:00', '2025-03-11 19:00:00', 10, 10),
('Session 11', 'image11.jpg', 'Summary 11', '2025-03-11 19:00:00', '2025-03-11 20:00:00', 10, 11),
('Session 12', 'image12.jpg', 'Summary 12', '2025-03-11 20:00:00', '2025-03-11 21:00:00', 10, 12),
('Session 13', 'image13.jpg', 'Summary 13', '2025-03-11 21:00:00', '2025-03-11 22:00:00', 10, 13),
('Session 14', 'image14.jpg', 'Summary 14', '2025-03-11 22:00:00', '2025-03-11 23:00:00', 10, 14),
('Session 15', 'image15.jpg', 'Summary 15', '2025-03-12 09:00:00', '2025-03-12 10:00:00', 10, 15),
('Session 16', 'image16.jpg', 'Summary 16', '2025-03-12 10:00:00', '2025-03-12 11:00:00', 10, 16),
('Session 17', 'image17.jpg', 'Summary 17', '2025-03-12 11:00:00', '2025-03-12 12:00:00', 10, 17),
('Session 18', 'image18.jpg', 'Summary 18', '2025-03-12 12:00:00', '2025-03-12 13:00:00', 10, 18),
('Session 19', 'image19.jpg', 'Summary 19', '2025-03-12 13:00:00', '2025-03-12 14:00:00', 10, 19),
('Session 20', 'image20.jpg', 'Summary 20', '2025-03-12 14:00:00', '2025-03-12 15:00:00', 10, 20);

```

Redis의 현재 내용
```
127.0.0.1:6379> keys *
1) "AT:google_112157892839058028210"
2) "session_congestion"
3) "RT:test@naver.com"
4) "RT:test@gmail.com"
5) "AT:naver_9z5fim7dZwsUM5b7ZK8zomDccNb1MZCJN38zdZ9hA0Y"
6) "session_user"
```

### 추가사항

### 구현 흐름
처음에는 스트리밍 방의 복잡도가 인원 수에 따라 달라지는 줄 알았는데, updateAndBroadcastIfChanged만 호출하는 흐름이라서 그에 맞춰 구현했습니다!

#### sessionService에 sessionId 대신 sessionNumber라는 새로운 필드를 사용한 이유

스트리밍에서는 1번 2번 청취방 과 같은 정보 roomName을 가지고 있습니다.

```java
public synchronized boolean addViewer(UserSession viewer, String roomName) {
		// 생략

		log.info("업데이트 할 룸 이름: {}", roomName); // TODO: 업데이트 할 룸 이름
		presenterUserSession.getWebRtcEndpoint().connect(viewerEndpoint); // Presenter와 연결
		
		viewers.put(viewer.getSession().getId(), viewer);
		log.info("현재 viewer 수: {}", viewers.size());
		return true;
	}
```

sessionId를 updateAndBroadcastIfChanged로 넘기기 위해 매번 스트리밍 입장 시 조회 쿼리 + 1 발생

```java
public void updateAndBroadcastIfChanged(Long sessionId) {
		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();

		double percent = getCongestionPercent(sessionId);
		String newLevel = getCongestionLevel(percent);

		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, sessionId);

		if (!newLevel.equals(previousLevel)) {
			hashOps.put(SESSION_CONGESTION_KEY, sessionId.toString(), newLevel);
			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
				"sessionId", sessionId,
				"percent", percent,
				"level", newLevel
			));
		}
```

새로운 필드 number로 진행 시 추가 쿼리 x
(1번 청취방, 2번 청취방 과 같은 정보(roomName)는 스트리밍에서 가지고 있기 때문 !)

```java
public void updateAndBroadcastIfChanged(Long number) {
		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();

		double percent = getCongestionPercent(number);
		String newLevel = getCongestionLevel(percent);

		String previousLevel = hashOps.get(SESSION_CONGESTION_KEY, number);

		if (!newLevel.equals(previousLevel)) {
			hashOps.put(SESSION_CONGESTION_KEY, number.toString(), newLevel);
			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
				"sessionId", number,
				"percent", percent,
				"level", newLevel
			));
		}
	}
```

이점: 스트리밍 방 입장 퇴장 시 DB 조회 쿼리를 1번 줄일 수 있다 !