### PR TITLE
[#29] 공용 응답 및 에러핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/eightplusone/bit/fit/domain/auth/controller/AuthController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.utils.CookieUtil;
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,7 +37,7 @@ public class AuthController {
 		@ApiResponse(responseCode = "401", description = "재발급 실패, 무결성이 침해되었습니다. 재 로그인이 필요합니다."),
 	})
 	@PostMapping("/reissue")
-	public ResponseEntity<?> reissue(HttpServletRequest request) {
+	public ResponseEntity<ResponseDto<Object>> reissue(HttpServletRequest request) {
 		String accessToken = tokenProvider.resolveAccessToken(request);
 		Claims claimsByAccessToken = tokenProvider.getClaimsByAccessToken(accessToken);
 
@@ -50,13 +51,13 @@ public class AuthController {
 				.header(
 					HttpHeaders.SET_COOKIE,
 					createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
-				.body(null);
+				.body(ResponseDto.fail(UNAUTHORIZED, "재발급 실패, 무결성이 침해되었습니다. 재 로그인이 필요합니다."));
 		}
 
 		String newAccessToken = tokenProvider.createAccessToken(subject, role, new Date());
 		return ResponseEntity.status(OK)
 			.header(AUTHORIZATION, newAccessToken)
-			.body(null);
+			.body(ResponseDto.success(OK, "재발급 성공", null));
 	}
 
 	@Operation(summary = "쿠키의 토큰 헤더로 변환하는 요청", description = "**성공 데이터:** 헤더의 `토큰`"
@@ -66,12 +67,12 @@ public class AuthController {
 		@ApiResponse(responseCode = "401", description = "변환 실패"),
 	})
 	@PostMapping("/token-exchange")
-	public ResponseEntity<?> exchange(HttpServletRequest request) {
+	public ResponseEntity<ResponseDto<Object>> exchange(HttpServletRequest request) {
 		String accessToken = CookieUtil.findCookieByName(request, ACCESS_TOKEN_COOKIE_NAME).getValue();
 		return ResponseEntity.status(OK)
 			.header(AUTHORIZATION, BEARER_PREFIX + accessToken)
 			.header(SET_COOKIE, createCookie(ACCESS_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
-			.body(null);
+			.body(ResponseDto.success(OK, "변환 성공", null));
 	}
 
 	@Operation(summary = "로그아웃 요청", description = "**성공 응답 데이터:**  브라우저 쿠키 초기화")
@@ -80,7 +81,7 @@ public class AuthController {
 		@ApiResponse(responseCode = "401", description = "로그아웃 실패"),
 	})
 	@PostMapping("/logout")
-	public ResponseEntity<?> logout() {
-		return ResponseEntity.status(OK).body(null);
+	public ResponseEntity<ResponseDto<Object>> logout() {
+		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "로그아웃 성공", null));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/CustomLogoutFilter.java
@@ -6,12 +6,14 @@ import java.io.IOException;
 import java.util.Date;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.GenericFilterBean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.utils.CookieUtil;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
@@ -62,7 +64,8 @@ public class CustomLogoutFilter extends GenericFilterBean {
 		response.setStatus(HttpServletResponse.SC_OK);
 		response.setCharacterEncoding("utf-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.getWriter().write(objectMapper.writeValueAsString(null));
+		response.getWriter()
+			.write(objectMapper.writeValueAsString(ResponseDto.success(HttpStatus.OK, "로그아웃 성공", null)));
 	}
 }
 

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -3,15 +3,18 @@ package eightplusone.bit.fit.domain.auth.filter;
 import java.io.IOException;
 import java.util.Arrays;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.enums.ApiEndpoint;
-import io.jsonwebtoken.IncorrectClaimException;
-import io.jsonwebtoken.JwtException;
+import eightplusone.bit.fit.global.exception.CustomException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final TokenProvider tokenProvider;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
@@ -44,21 +48,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		try {
 			if (!tokenProvider.validateAccessToken(accessToken)) {
-				throw new JwtException("잘못된 토큰 입니다.");
+				sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰 입니다.");
+				return;
 			}
 			Authentication authentication = tokenProvider.getAuthenticationByAccessToken(accessToken);
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 
-		} catch (IncorrectClaimException e) {
+		} catch (CustomException e) {
 			SecurityContextHolder.clearContext();
-			log.debug("잘못된 토큰 입니다.");
-			throw new JwtException("잘못된 토큰 입니다.", e);
-		} catch (UsernameNotFoundException e) {
-			SecurityContextHolder.clearContext();
-			log.debug("회원을 찾을 수 없습니다.");
-			throw new UsernameNotFoundException("회원을 찾을 수 없습니다.");
+			sendErrorResponse(response, HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+			return;
 		}
 		filterChain.doFilter(request, response);
+	}
+
+	private void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+		response.setStatus(status.value());
+		response.setCharacterEncoding("utf-8");
+		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+		response.getWriter().write(objectMapper.writeValueAsString(
+			ResponseDto.fail(status, message)));
 	}
 
 	protected boolean shouldNotFilter(HttpServletRequest request) {

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
@@ -31,6 +31,6 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 		response.setCharacterEncoding("utf-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 		response.getWriter().write(objectMapper.writeValueAsString(
-			ResponseDto.fail(HttpStatus.UNAUTHORIZED, "권한이 없습니다")));
+			ResponseDto.fail(HttpStatus.FORBIDDEN, "권한이 없습니다")));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAccessDeniedHandler.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +30,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 		response.setStatus(HttpStatus.FORBIDDEN.value());
 		response.setCharacterEncoding("utf-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.getWriter().write(objectMapper.writeValueAsString("권한이 없습니다"));
+		response.getWriter().write(objectMapper.writeValueAsString(
+			ResponseDto.fail(HttpStatus.UNAUTHORIZED, "권한이 없습니다")));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/handler/CustomAuthenticationEntryPoint.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 		response.setStatus(HttpStatus.UNAUTHORIZED.value());
 		response.setCharacterEncoding("utf-8");
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.getWriter().write(objectMapper.writeValueAsString("잘못된 접근 입니다."));
+		response.getWriter().write(objectMapper.writeValueAsString(
+			ResponseDto.fail(HttpStatus.UNAUTHORIZED, "잘못된 접근 입니다.")));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/jwt/TokenProvider.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/jwt/TokenProvider.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Component;
 import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
 import eightplusone.bit.fit.domain.auth.service.CustomUserDetailsService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.global.exception.CustomException;
+import eightplusone.bit.fit.global.exception.ErrorCode;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -124,7 +126,9 @@ public class TokenProvider {
 			return e.getClaims();
 		} catch (JwtException e) {
 			log.error("잘못된 jwt 토큰입니다. {}", e.getMessage());
-			throw new IllegalArgumentException("잘못된 jwt 토큰 입니다.");
+			throw new CustomException(ErrorCode.INVALID_AUTH_TOKEN);
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.INVALID_AUTH_TOKEN);
 		}
 	}
 

--- a/src/main/java/eightplusone/bit/fit/domain/auth/service/OAuth2UnlinkService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/service/OAuth2UnlinkService.java
@@ -11,6 +11,8 @@ import org.springframework.web.client.RestTemplate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import eightplusone.bit.fit.global.exception.CustomException;
+import eightplusone.bit.fit.global.exception.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -38,15 +40,15 @@ public class OAuth2UnlinkService {
 		} else if (provider.startsWith("naver")) {
 			naverUnlink(provider);
 		} else {
-			throw new IllegalStateException("허용되지 않은 소셜 로그인 제공자");
+			throw new CustomException(ErrorCode.INVALID_REQUEST);
 		}
 	}
-	
+
 	private void googleUnlink(String provider) {
 		String accessToken = redisTokenService.getOauth2AccessToken(provider);
 		// oauth2 토큰이 만료 시 재 로그인
 		if (accessToken == null) {
-			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+			throw new CustomException(ErrorCode.EXPIRED_AUTH_TOKEN);
 		}
 		// 바디 설정
 		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -58,7 +60,7 @@ public class OAuth2UnlinkService {
 		String accessToken = redisTokenService.getOauth2AccessToken(provider);
 		// oauth2 토큰이 만료 시 재 로그인
 		if (accessToken == null) {
-			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+			throw new CustomException(ErrorCode.EXPIRED_AUTH_TOKEN);
 		}
 		HttpHeaders headers = new HttpHeaders();
 		headers.setBearerAuth(accessToken);
@@ -71,7 +73,7 @@ public class OAuth2UnlinkService {
 		String accessToken = redisTokenService.getOauth2AccessToken(provider);
 
 		if (accessToken == null) {
-			throw new IllegalStateException("소셜 로그인 토큰 만료, 재로그인 필요");
+			throw new CustomException(ErrorCode.EXPIRED_AUTH_TOKEN);
 		}
 
 		String url = NAVER_URL
@@ -87,7 +89,7 @@ public class OAuth2UnlinkService {
 		NaverUnlinkResponse response = restTemplate.getForObject(url, NaverUnlinkResponse.class);
 
 		if (response != null && !"success".equalsIgnoreCase(response.getResult())) {
-			throw new IllegalStateException("소셜 로그인 연결 끊기 실패");
+			throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 	}
 

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.user.service.UserService;
+import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.utils.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,11 +31,11 @@ public class UserController {
 		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다. 재 로그인 후 탈퇴를 시도하세요."),
 	})
 	@DeleteMapping
-	public ResponseEntity<?> delete() {
+	public ResponseEntity<ResponseDto<Object>> delete() {
 		userService.delete();
 		return ResponseEntity.status(CREATED)
 			.header(HttpHeaders.SET_COOKIE,
 				CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
-			.body(null);
+			.body(ResponseDto.success(CREATED, "회원 탈퇴 완료", null));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -90,7 +90,8 @@ public class SecurityConfig {
 				.anyRequest()
 				.permitAll() // 모든 요청 허용
 			)
-			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+			.addFilterAfter(new JwtAuthenticationFilter(tokenProvider, objectMapper),
+				UsernamePasswordAuthenticationFilter.class)
 			.addFilterBefore(new CustomLogoutFilter(tokenProvider, objectMapper), LogoutFilter.class)
 			.oauth2Login((oauth2) -> oauth2.userInfoEndpoint(
 					(userInfoEndpointConfig -> userInfoEndpointConfig.userService(customOAuth2UserService)))

--- a/src/main/java/eightplusone/bit/fit/global/dto/ResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/global/dto/ResponseDto.java
@@ -1,0 +1,41 @@
+package eightplusone.bit.fit.global.dto;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+
+	private final boolean success;
+	private final String statusName;
+	private final String message;
+	private final T response;
+
+	@Builder
+	private ResponseDto(boolean success, String statusName, String message, T response) {
+		this.success = success;
+		this.statusName = statusName;
+		this.message = message;
+		this.response = response;
+	}
+
+	public static <T> ResponseDto<T> success(HttpStatus status, String message, T data) {
+		return ResponseDto.<T>builder()
+			.success(true)
+			.statusName(status.name())
+			.message(message)
+			.response(data)
+			.build();
+	}
+
+	public static <T> ResponseDto<T> fail(HttpStatus status, String message) {
+		return ResponseDto.<T>builder()
+			.success(false)
+			.statusName(status.name())
+			.message(message)
+			.response(null)
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/global/exception/CustomException.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/CustomException.java
@@ -1,10 +1,13 @@
 package eightplusone.bit.fit.global.exception;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class CustomException extends RuntimeException {
-	ErrorCode errorCode;
+	private final ErrorCode errorCode;
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/exception/CustomException.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/CustomException.java
@@ -1,0 +1,10 @@
+package eightplusone.bit.fit.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+	ErrorCode errorCode;
+}

--- a/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
@@ -15,14 +15,14 @@ import eightplusone.bit.fit.global.dto.ResponseDto;
 public class CustomExceptionHandler {
 
 	@ExceptionHandler(CustomException.class)
-	protected ResponseEntity<ResponseDto> handleCustomException(CustomException e) {
+	protected ResponseEntity<ResponseDto<Object>> handleCustomException(CustomException e) {
 		ErrorCode errorCode = e.getErrorCode();
 		HttpStatus status = errorCode.getHttpStatus();
 		return ResponseEntity.status(status).body(ResponseDto.fail(status, errorCode.getMessage()));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	ResponseEntity<ResponseDto> handleValidationException(MethodArgumentNotValidException e) {
+	ResponseEntity<ResponseDto<Object>> handleValidationException(MethodArgumentNotValidException e) {
 		FieldError fieldError = e.getBindingResult()
 			.getFieldErrors()
 			.get(e.getBindingResult().getFieldErrors().size() - 1);

--- a/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
@@ -1,0 +1,32 @@
+package eightplusone.bit.fit.global.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import eightplusone.bit.fit.global.dto.ResponseDto;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+	@ExceptionHandler(CustomException.class)
+	protected ResponseEntity<ResponseDto> handleCustomException(CustomException e) {
+		ErrorCode errorCode = e.getErrorCode();
+		HttpStatus status = errorCode.getHttpStatus();
+		return ResponseEntity.status(status).body(ResponseDto.fail(status, errorCode.getMessage()));
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	ResponseEntity<ResponseDto> handleValidationException(MethodArgumentNotValidException e) {
+		FieldError fieldError = e.getBindingResult()
+			.getFieldErrors()
+			.get(e.getBindingResult().getFieldErrors().size() - 1);
+		String message = fieldError.getField() + " 필드의 입력값[ " + fieldError.getRejectedValue() + " ]이 유효하지 않습니다.";
+		return ResponseEntity.status(BAD_REQUEST).body(ResponseDto.fail(HttpStatus.BAD_REQUEST, message));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/global/exception/ErrorCode.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/ErrorCode.java
@@ -1,0 +1,50 @@
+package eightplusone.bit.fit.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+	/**
+	 * 400 BAD_REQUEST : 잘못된 요청
+	 */
+	INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+	/**
+	 * 401 UNAUTHORIZED : 인증 되지 않은 사용자
+	 */
+	INVALID_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "권한 정보가 없는 토큰입니다."),
+	EXPIRED_AUTH_TOKEN(HttpStatus.UNAUTHORIZED, "인증 토큰이 만료되었습니다."),
+
+	/**
+	 * 403 FORBIDDEN : 권한 없음
+	 */
+	ACCESS_DENIED(HttpStatus.FORBIDDEN, "해당 자원에 대한 접근 권한이 없습니다."),
+
+	/**
+	 * 404 NOT_FOUND : Resource 를 찾을 수 없음
+	 */
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당하는 정보의 사용자를 찾을 수 없습니다."),
+	RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+
+	/**
+	 * 409 : CONFLICT : Resource 의 현재 상태와 충돌
+	 */
+	DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일 입니다."),
+	DUPLICATE_RESOURCE(HttpStatus.CONFLICT, "데이터가 이미 존재합니다."),
+	RESOURCE_CONFLICT(HttpStatus.CONFLICT, "리소스 상태와 충돌이 발생했습니다."),
+	OVER_VALIDATION(HttpStatus.CONFLICT,"더 이상 데이터를 저장 할 수 없습니다."),
+
+	/**
+	 * 500 INTERNAL_SERVER_ERROR : 서버 오류
+	 */
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에서 오류가 발생했습니다. 관리자에게 문의하세요."),
+	DATABASE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 오류가 발생했습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
+++ b/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
@@ -2,6 +2,8 @@ package eightplusone.bit.fit.global.utils;
 
 import org.springframework.http.ResponseCookie;
 
+import eightplusone.bit.fit.global.exception.CustomException;
+import eightplusone.bit.fit.global.exception.ErrorCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -25,6 +27,6 @@ public final class CookieUtil {
 				}
 			}
 		}
-		throw new NullPointerException(name + " 쿠키를 찾을 수 없습니다.");
+		throw new CustomException(ErrorCode.INVALID_REQUEST);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/auth/jwt/TokenProviderTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/auth/jwt/TokenProviderTest.java
@@ -20,6 +20,7 @@ import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
 import eightplusone.bit.fit.domain.auth.service.CustomUserDetailsService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.entity.User;
+import eightplusone.bit.fit.global.exception.CustomException;
 import eightplusone.bit.fit.support.fixture.UserFixture;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -428,7 +429,7 @@ class TokenProviderTest {
 
 		// when & then
 		assertThatThrownBy(() -> tokenProvider.getClaimsByAccessToken(invalidToken))
-			.isInstanceOf(IllegalArgumentException.class);
+			.isInstanceOf(CustomException.class);
 	}
 
 	private Claims parseTokenSubject(String token, String secretKey) {

--- a/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
+++ b/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseCookie;
 
+import eightplusone.bit.fit.global.exception.CustomException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -63,8 +64,8 @@ class CookieUtilTest {
 		when(request.getCookies()).thenReturn(mockCookies);
 
 		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
-			.isInstanceOf(NullPointerException.class)
-			.hasMessageContaining(COOKIE_NAME + " 쿠키를 찾을 수 없습니다.");
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining("잘못된 요청입니다.");
 	}
 
 	@Test
@@ -76,7 +77,7 @@ class CookieUtilTest {
 
 		// when & then
 		assertThatThrownBy(() -> CookieUtil.findCookieByName(request, COOKIE_NAME))
-			.isInstanceOf(NullPointerException.class)
-			.hasMessageContaining(COOKIE_NAME + " 쿠키를 찾을 수 없습니다.");
+			.isInstanceOf(CustomException.class)
+			.hasMessageContaining("잘못된 요청입니다.");
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [x] 테스트 코드 추가 및 리팩토링
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#29 ]


### 변경 사항
- ResponseDto 추가
- CustomException 핸들러 추가
- 해당 추가 사항 user auth security 에 적용

### 테스트 결과
![스크린샷 2025-03-11 오후 7 42 44](https://github.com/user-attachments/assets/5d53bdce-3af6-4243-826e-41b862c5f650)
- 전체 테스트 통과

![스크린샷 2025-03-11 오후 6 46 49](https://github.com/user-attachments/assets/271b1060-8a34-45e5-901d-629986939ef1)
에러핸들러를 통한 공용 응답 데이터로 테스트

### 추가 사항
스프링 최신 버젼과 Swagger 버젼 충돌 문제 2.7버젼으로 번경하며 해결.
[참고한 블로그](https://blog.everdu.com/558)