### PR TITLE
Chore #35 deploy token update

### DIFF
--- a/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
+++ b/src/main/java/eightplusone/bit/fit/global/utils/CookieUtil.java
@@ -13,7 +13,7 @@ public final class CookieUtil {
 		return ResponseCookie.from(name, value)
 			.maxAge(cookieExpiration)
 			.path("/")
-			.sameSite("Strict")
+			.sameSite("Lax")
 			.httpOnly(true)
 			.build();
 	}

--- a/src/test/java/eightplusone/bit/fit/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/auth/controller/AuthControllerTest.java
@@ -80,7 +80,7 @@ class AuthControllerTest {
 			.andExpect(header().string(SET_COOKIE, containsString("Path=/")))
 			.andExpect(header().string(SET_COOKIE, containsString("Max-Age=0")))
 			.andExpect(header().string(SET_COOKIE, containsString("HttpOnly")))
-			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Strict")))
+			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Lax")))
 			.andDo(print());
 	}
 
@@ -135,7 +135,7 @@ class AuthControllerTest {
 			.andExpect(header().string(SET_COOKIE, containsString("Path=/")))
 			.andExpect(header().string(SET_COOKIE, containsString("Max-Age=0")))
 			.andExpect(header().string(SET_COOKIE, containsString("HttpOnly")))
-			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Strict")))
+			.andExpect(header().string(SET_COOKIE, containsString("SameSite=Lax")))
 			.andDo(print());
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
+++ b/src/test/java/eightplusone/bit/fit/global/utils/CookieUtilTest.java
@@ -31,7 +31,7 @@ class CookieUtilTest {
 			() -> assertThat(cookie.getValue()).isEqualTo(COOKIE_VALUE),
 			() -> assertThat(cookie.getMaxAge().getSeconds()).isEqualTo(COOKIE_EXPIRATION),
 			() -> assertThat(cookie.getPath()).isEqualTo("/"),
-			() -> assertThat(cookie.getSameSite()).isEqualTo("Strict"),
+			() -> assertThat(cookie.getSameSite()).isEqualTo("Lax"),
 			() -> assertThat(cookie.isHttpOnly()).isTrue()
 		);
 	}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#35]

### 변경 사항
- yml 토큰 시간 3주로 연장
- 쿠키 SameSite=Lax로 변경

Lax 적용 시 Post의 쿠키 전송이 안된다고 하는데, 로컬 도메인이 일치해서 그런지 전송이 되네요.
확실하게 배포가 될 때 테스트 후 Post -> Get으로 임시 변경을 진행 할 지 검토해보도록 하겠습니다 !

### 테스트 결과
![스크린샷 2025-03-13 오후 4 52 20](https://github.com/user-attachments/assets/4d986582-b07f-4a5d-981a-8ff737e6fa84)
로그인 후 토큰 시간이 연장 되었는지 확인

![스크린샷 2025-03-13 오후 5 05 41](https://github.com/user-attachments/assets/a6e40505-c7a4-460e-9a7a-dd7c62de93e9)

![스크린샷 2025-03-13 오후 5 05 17](https://github.com/user-attachments/assets/c77a93ba-b9b3-4f69-b74c-52bb7c9c1834)

쿠키가 Lax인지 확인