### PR TITLE
[#37] 네이버 로그인 검수를 위한 사용자 기본 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -7,11 +7,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
 import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileUpdateRequestDto;
 import eightplusone.bit.fit.domain.user.service.UserService;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.utils.CookieUtil;
@@ -60,5 +63,18 @@ public class UserController {
 	@GetMapping("/profile")
 	public ResponseEntity<ResponseDto<UserProfileResponseDto>> getProfile() {
 		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 개인 정보 조회 성공", userService.getProfileInfo()));
+	}
+
+	@Operation(summary = "회원 개인 정보 업데이트", description = "**성공 응답 데이터:**  null")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "회원 개인 정보 업데이트 성공"),
+		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
+		@ApiResponse(responseCode = "404", description = "업데이트 필드 값 오류"),
+	})
+	@PutMapping("/profile")
+	public ResponseEntity<ResponseDto<Object>> updateProfile(
+		@RequestBody UserProfileUpdateRequestDto userProfileUpdateRequestDto) {
+		userService.updateProfileInfo(userProfileUpdateRequestDto);
+		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 개인 정보 업데이트 성공", null));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -6,6 +6,7 @@ import static org.springframework.http.HttpStatus.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -37,5 +38,15 @@ public class UserController {
 			.header(HttpHeaders.SET_COOKIE,
 				CookieUtil.createCookie(REFRESH_TOKEN_COOKIE_NAME, null, REFRESH_EXPIRATION_DELETE).toString())
 			.body(ResponseDto.success(CREATED, "회원 탈퇴 완료", null));
+	}
+
+	@Operation(summary = "회원 계정 정보 조회", description = "**성공 응답 데이터:**  회원 계정 정보")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "회원 계정 정보 조회 성공"),
+		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
+	})
+	@GetMapping("/account")
+	public ResponseEntity<ResponseDto<Object>> getAccount() {
+		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 계정 정보 조회 성공", userService.getAccountInfo()));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -21,6 +21,7 @@ import eightplusone.bit.fit.global.utils.CookieUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -73,7 +74,7 @@ public class UserController {
 	})
 	@PutMapping("/profile")
 	public ResponseEntity<ResponseDto<Object>> updateProfile(
-		@RequestBody UserProfileUpdateRequestDto userProfileUpdateRequestDto) {
+		@Valid @RequestBody UserProfileUpdateRequestDto userProfileUpdateRequestDto) {
 		userService.updateProfileInfo(userProfileUpdateRequestDto);
 		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 개인 정보 업데이트 성공", null));
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
 import eightplusone.bit.fit.domain.user.service.UserService;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.utils.CookieUtil;
@@ -46,7 +48,17 @@ public class UserController {
 		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
 	})
 	@GetMapping("/account")
-	public ResponseEntity<ResponseDto<Object>> getAccount() {
+	public ResponseEntity<ResponseDto<UserAccountResponseDto>> getAccount() {
 		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 계정 정보 조회 성공", userService.getAccountInfo()));
+	}
+
+	@Operation(summary = "회원 개인 정보 조회", description = "**성공 응답 데이터:**  회원 개인 정보")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "회원 개인 정보 조회 성공"),
+		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
+	})
+	@GetMapping("/profile")
+	public ResponseEntity<ResponseDto<UserProfileResponseDto>> getProfile() {
+		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "회원 개인 정보 조회 성공", userService.getProfileInfo()));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/controller/UserController.java
@@ -69,8 +69,8 @@ public class UserController {
 	@Operation(summary = "회원 개인 정보 업데이트", description = "**성공 응답 데이터:**  null")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "회원 개인 정보 업데이트 성공"),
+		@ApiResponse(responseCode = "400", description = "업데이트 필드 값 오류"),
 		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
-		@ApiResponse(responseCode = "404", description = "업데이트 필드 값 오류"),
 	})
 	@PutMapping("/profile")
 	public ResponseEntity<ResponseDto<Object>> updateProfile(

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
@@ -1,0 +1,23 @@
+package eightplusone.bit.fit.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserAccountResponseDto {
+	private final String name;
+	private final String email;
+
+	@Builder
+	private UserAccountResponseDto(String name, String email) {
+		this.name = name;
+		this.email = email;
+	}
+
+	public static UserAccountResponseDto of(String name, String email) {
+		return UserAccountResponseDto.builder()
+			.name(name)
+			.email(email)
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
@@ -1,11 +1,16 @@
 package eightplusone.bit.fit.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Schema(name = "UserAccountResponseDto: 회원 계정 정보 Dto")
 public class UserAccountResponseDto {
+
+	@Schema(description = "사용자 이름", example = "홍길동")
 	private final String name;
+	@Schema(description = "사용자 이메일", example = "test@gmail.com")
 	private final String email;
 
 	@Builder

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
@@ -1,12 +1,18 @@
 package eightplusone.bit.fit.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Schema(name = "UserProfileResponseDto: 회원 개인 정보 Dto")
 public class UserProfileResponseDto {
+
+	@Schema(description = "직무", example = "백엔드")
 	private final String job;
+	@Schema(description = "연차", example = "1")
 	private final Integer years;
+	@Schema(description = "관심 분야", example = "클라우드")
 	private final String interests;
 
 	@Builder

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,26 @@
+package eightplusone.bit.fit.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponseDto {
+	private final String job;
+	private final Integer years;
+	private final String interests;
+
+	@Builder
+	private UserProfileResponseDto(String job, Integer years, String interests) {
+		this.job = job;
+		this.years = years;
+		this.interests = interests;
+	}
+
+	public static UserProfileResponseDto of(String job, Integer years, String interests) {
+		return UserProfileResponseDto.builder()
+			.job(job)
+			.years(years)
+			.interests(interests)
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileUpdateRequestDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileUpdateRequestDto.java
@@ -1,0 +1,29 @@
+package eightplusone.bit.fit.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserProfileUpdateRequestDto {
+
+	private String job;
+	private Integer years;
+	private String interests;
+
+	@Builder
+	private UserProfileUpdateRequestDto(String job, Integer years, String interests) {
+		this.job = job;
+		this.years = years;
+		this.interests = interests;
+	}
+
+	public static UserProfileUpdateRequestDto of(String job, Integer years, String interests) {
+		return UserProfileUpdateRequestDto.builder()
+			.job(job)
+			.years(years)
+			.interests(interests)
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileUpdateRequestDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileUpdateRequestDto.java
@@ -1,15 +1,29 @@
 package eightplusone.bit.fit.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@Schema(name = "UserProfileUpdateRequestDto: 회원 개인 정보 업데이트 Dto")
 public class UserProfileUpdateRequestDto {
 
+	@NotBlank(message = "직무가 입력되지 않았습니다.")
+	@Schema(description = "직무", example = "백엔드")
 	private String job;
+
+	@Min(value = 0, message = "연차는 0 이상이어야 합니다.")
+	@NotNull(message = "연차가 입력되지 않았습니다.")
+	@Schema(description = "연차", example = "1")
 	private Integer years;
+
+	@NotBlank(message = "관심 분야가 입력되지 않았습니다.")
+	@Schema(description = "관심 분야", example = "클라우드")
 	private String interests;
 
 	@Builder

--- a/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
@@ -51,10 +51,13 @@ public class User extends BaseTimeEntity {
 	private Role role;
 
 	@Builder
-	private User(String email, String name, String provider, Role role) {
+	private User(String email, String name, String provider, String job, Integer years, String interests, Role role) {
 		this.email = email;
 		this.name = name;
 		this.provider = provider;
+		this.job = job;
+		this.years = years;
+		this.interests = interests;
 		this.role = role;
 	}
 

--- a/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
@@ -69,4 +69,10 @@ public class User extends BaseTimeEntity {
 			.role(role)
 			.build();
 	}
+
+	public void updateProfileInfo(String job, Integer years, String interests) {
+		this.job = job;
+		this.years = years;
+		this.interests = interests;
+	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,5 +42,11 @@ public class UserService {
 		User user = userRepository.findLoginUserByEmail(
 			SecurityContextHolder.getContext().getAuthentication().getName());
 		return UserAccountResponseDto.of(user.getName(), user.getEmail());
+	}
+
+	public UserProfileResponseDto getProfileInfo() {
+		User user = userRepository.findLoginUserByEmail(
+			SecurityContextHolder.getContext().getAuthentication().getName());
+		return UserProfileResponseDto.of(user.getJob(), user.getYears(), user.getInterests());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
 import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileUpdateRequestDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +49,15 @@ public class UserService {
 		User user = userRepository.findLoginUserByEmail(
 			SecurityContextHolder.getContext().getAuthentication().getName());
 		return UserProfileResponseDto.of(user.getJob(), user.getYears(), user.getInterests());
+	}
+
+	@Transactional
+	public void updateProfileInfo(UserProfileUpdateRequestDto userProfileUpdateRequestDto) {
+		User user = userRepository.findLoginUserByEmail(
+			SecurityContextHolder.getContext().getAuthentication().getName());
+		user.updateProfileInfo(
+			userProfileUpdateRequestDto.getJob(),
+			userProfileUpdateRequestDto.getYears(),
+			userProfileUpdateRequestDto.getInterests());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,5 +35,11 @@ public class UserService {
 		if (redisTokenService.getOauth2AccessToken(provider) != null) {
 			redisTokenService.deleteOauth2AccessToken(provider);
 		}
+	}
+
+	public UserAccountResponseDto getAccountInfo() {
+		User user = userRepository.findLoginUserByEmail(
+			SecurityContextHolder.getContext().getAuthentication().getName());
+		return UserAccountResponseDto.of(user.getName(), user.getEmail());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -34,6 +34,7 @@ public enum ApiEndpoint {
 	}),
 
 	AUTHENTICATED_PUT(HttpMethod.PUT, new String[] {
+		"/api/v1/users/profile"
 	}),
 
 	AUTHENTICATED_PATCH(HttpMethod.PATCH, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -23,7 +23,8 @@ public enum ApiEndpoint {
 	}),
 
 	AUTHENTICATED_GET(HttpMethod.GET, new String[] {
-		"/api/v1/users/account"
+		"/api/v1/users/account",
+		"/api/v1/users/profile"
 	}),
 
 	AUTHENTICATED_POST(HttpMethod.POST, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -23,6 +23,7 @@ public enum ApiEndpoint {
 	}),
 
 	AUTHENTICATED_GET(HttpMethod.GET, new String[] {
+		"/api/v1/users/account"
 	}),
 
 	AUTHENTICATED_POST(HttpMethod.POST, new String[] {

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -22,6 +22,7 @@ import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
 import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileUpdateRequestDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.support.fixture.UserFixture;
@@ -109,6 +110,33 @@ class UserServiceTest {
 			() -> assertThat(profileInfo.getJob()).isEqualTo(user.getJob()),
 			() -> assertThat(profileInfo.getYears()).isEqualTo(user.getYears()),
 			() -> assertThat(profileInfo.getInterests()).isEqualTo(user.getInterests())
+		);
+	}
+
+	@Test
+	@DisplayName("회원 개인 정보를 조회한다")
+	void userProfileUpdate() {
+		//given
+		User user = UserFixture.USER_FIXTURE_1.createUser();
+
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+			new CustomUserDetails(user), null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())));
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+
+		Mockito.when(userRepository.findLoginUserByEmail(user.getEmail())).thenReturn(user);
+
+		UserProfileUpdateRequestDto userProfileUpdateRequestDto = UserProfileUpdateRequestDto.of("디자이너", 10, "css");
+
+		//when
+		userService.updateProfileInfo(userProfileUpdateRequestDto);
+
+		//then
+		assertAll(
+			() -> assertThat(user.getJob()).isEqualTo("디자이너"),
+			() -> assertThat(user.getYears()).isEqualTo(10),
+			() -> assertThat(user.getInterests()).isEqualTo("css")
 		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -1,5 +1,8 @@
 package eightplusone.bit.fit.domain.user.service;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +20,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
 import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
+import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.support.fixture.UserFixture;
@@ -56,5 +60,29 @@ class UserServiceTest {
 
 		//then
 		Mockito.verify(userRepository, Mockito.times(1)).delete(user);
+	}
+
+	@Test
+	@DisplayName("회원 계정 정보를 조회한다")
+	void userAccountGet() {
+		//given
+		User user = UserFixture.USER_FIXTURE_1.createUser();
+
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+			new CustomUserDetails(user), null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())));
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+
+		Mockito.when(userRepository.findLoginUserByEmail(user.getEmail())).thenReturn(user);
+
+		//when
+		UserAccountResponseDto accountInfo = userService.getAccountInfo();
+
+		//then
+		assertAll(
+			() -> assertThat(accountInfo.getName()).isEqualTo(user.getName()),
+			() -> assertThat(accountInfo.getEmail()).isEqualTo(user.getEmail())
+		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -114,7 +114,7 @@ class UserServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원 개인 정보를 조회한다")
+	@DisplayName("회원 개인 정보를 업데이트한다")
 	void userProfileUpdate() {
 		//given
 		User user = UserFixture.USER_FIXTURE_1.createUser();

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -21,6 +21,7 @@ import eightplusone.bit.fit.domain.auth.dto.CustomUserDetails;
 import eightplusone.bit.fit.domain.auth.service.OAuth2UnlinkService;
 import eightplusone.bit.fit.domain.auth.service.RedisTokenService;
 import eightplusone.bit.fit.domain.user.dto.UserAccountResponseDto;
+import eightplusone.bit.fit.domain.user.dto.UserProfileResponseDto;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.support.fixture.UserFixture;
@@ -83,6 +84,31 @@ class UserServiceTest {
 		assertAll(
 			() -> assertThat(accountInfo.getName()).isEqualTo(user.getName()),
 			() -> assertThat(accountInfo.getEmail()).isEqualTo(user.getEmail())
+		);
+	}
+
+	@Test
+	@DisplayName("회원 개인 정보를 조회한다")
+	void userProfileGet() {
+		//given
+		User user = UserFixture.USER_FIXTURE_1.createUser();
+
+		SecurityContext context = SecurityContextHolder.createEmptyContext();
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+			new CustomUserDetails(user), null, List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole())));
+		context.setAuthentication(authentication);
+		SecurityContextHolder.setContext(context);
+
+		Mockito.when(userRepository.findLoginUserByEmail(user.getEmail())).thenReturn(user);
+
+		//when
+		UserProfileResponseDto profileInfo = userService.getProfileInfo();
+
+		//then
+		assertAll(
+			() -> assertThat(profileInfo.getJob()).isEqualTo(user.getJob()),
+			() -> assertThat(profileInfo.getYears()).isEqualTo(user.getYears()),
+			() -> assertThat(profileInfo.getInterests()).isEqualTo(user.getInterests())
 		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/UserFixture.java
@@ -6,19 +6,25 @@ import lombok.Getter;
 
 @Getter
 public enum UserFixture {
-	USER_FIXTURE_1("google_test1", "test@gmail.com", "홍길동", Role.USER),
-	USER_FIXTURE_2("google_test2", "test2@gmail.com", "존도", Role.USER),
-	USER_FIXTURE_3("google_test3", "test3@gmail.com", "제인도", Role.USER);
+	USER_FIXTURE_1("google_test1", "test@gmail.com", "홍길동", "백엔드", 1, "데이터베이스", Role.USER),
+	USER_FIXTURE_2("google_test2", "test2@gmail.com", "존도", "프론트엔드", 2, "협업", Role.USER),
+	USER_FIXTURE_3("google_test3", "test3@gmail.com", "제인도", "데브옵스", 3, "클라우드", Role.USER);
 
 	private final String provider;
 	private final String email;
 	private final String name;
+	private final String job;
+	private final Integer years;
+	private final String interests;
 	private final Role role;
 
-	UserFixture(String provider, String email, String name, Role role) {
+	UserFixture(String provider, String email, String name, String job, Integer years, String interests, Role role) {
 		this.provider = provider;
 		this.email = email;
 		this.name = name;
+		this.job = job;
+		this.years = years;
+		this.interests = interests;
 		this.role = role;
 	}
 
@@ -27,6 +33,9 @@ public enum UserFixture {
 			.provider(provider)
 			.email(email)
 			.name(name)
+			.job(job)
+			.years(years)
+			.interests(interests)
 			.role(role)
 			.build();
 	}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#37]

### 변경 사항

와이어프레임 마이페이지 기준으로 네이버 로그인 검수에 필요할 것 같은 API 를 제작했습니다.
- validation 의존성을 추가했습니다.
- 계정 정보(이메일, 이름) 조회 기능
- 개인 정보(직무, 연차, 관심 분야) 조회 기능
- 개인 정보 업데이트 기능

### 테스트 결과
![스크린샷 2025-03-14 오후 4 01 06](https://github.com/user-attachments/assets/b512c708-533d-42a0-807f-f7636509a3f5)
validation 적용 테스트

![스크린샷 2025-03-14 오후 2 50 31](https://github.com/user-attachments/assets/b878ecbc-c79c-4bf1-b0ec-3ccd8e835e61)
작성된 API 에 대한 테스트를 모두 진행했습니다.

![스크린샷 2025-03-14 오후 5 00 12](https://github.com/user-attachments/assets/dd357d43-d3ad-4a7c-aaed-9289ce2abc12)
Service 테스트 코드를 작성했습니다.

### 추가 사항
![스크린샷 2025-03-14 오후 4 58 00](https://github.com/user-attachments/assets/66b3cf2d-774e-4df0-ba9d-c8e000bb3531)

스키마 내용이 ResponseDto로 중복이 되어 보이는데 해결방법을 모르겠네요 !
추후에 함께 알아보면 좋을 것 같습니다 !




