### PR TITLE
[#43] endpoint 수정

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,16 @@
 package eightplusone.bit.fit.domain.auth.filter;
 
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.enums.ApiEndpoint;
@@ -9,15 +19,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -70,12 +73,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 	protected boolean shouldNotFilter(HttpServletRequest request) {
 		String requestUri = request.getRequestURI();
 		String upgradeHeader = request.getHeader("Upgrade");
-		String requestUrl = request.getRequestURL().toString();
-
-		if (requestUri.startsWith("/ws") || requestUri.startsWith("/sub/session") || requestUrl.startsWith(
-			"https://jiangxy.github.io")) { // TODO : 마지막 조건문 삭제
-			return true;
-		} // 혼잡도 관련 -> 토큰 인증 X
 
 		return Arrays.stream(ApiEndpoint.values())
 			.filter(endpoint -> endpoint.name().startsWith("PUBLIC_"))
@@ -83,9 +80,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			.map(path -> path.replace("**", ".*"))
 			.anyMatch(requestUri::matches)
 			|| (upgradeHeader != null && upgradeHeader.equalsIgnoreCase("websocket")
-			|| requestUri.startsWith("/ws")
-			|| requestUri.startsWith("/sub/session")
-			|| requestUrl.startsWith("https://jiangxy.github.io") // TODO : 마지막 조건문 삭제
 		);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,16 +1,6 @@
 package eightplusone.bit.fit.domain.auth.filter;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import eightplusone.bit.fit.domain.auth.jwt.TokenProvider;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import eightplusone.bit.fit.global.enums.ApiEndpoint;
@@ -19,8 +9,15 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -75,8 +72,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		String upgradeHeader = request.getHeader("Upgrade");
 		String requestUrl = request.getRequestURL().toString();
 
-		if (requestUri.startsWith("/ws-room") || requestUri.startsWith("/sub/session") || requestUrl.startsWith(
-			"https://jiangxy.github.io") || requestUri.startsWith("/ws-chat")) { // TODO : 마지막 조건문 삭제
+		if (requestUri.startsWith("/ws") || requestUri.startsWith("/sub/session") || requestUrl.startsWith(
+			"https://jiangxy.github.io")) { // TODO : 마지막 조건문 삭제
 			return true;
 		} // 혼잡도 관련 -> 토큰 인증 X
 
@@ -86,7 +83,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			.map(path -> path.replace("**", ".*"))
 			.anyMatch(requestUri::matches)
 			|| (upgradeHeader != null && upgradeHeader.equalsIgnoreCase("websocket")
-			|| requestUri.startsWith("/ws-room")
+			|| requestUri.startsWith("/ws")
 			|| requestUri.startsWith("/sub/session")
 			|| requestUrl.startsWith("https://jiangxy.github.io") // TODO : 마지막 조건문 삭제
 		);

--- a/src/main/java/eightplusone/bit/fit/domain/auth/interceptor/WebSocketInterceptor.java
+++ b/src/main/java/eightplusone/bit/fit/domain/auth/interceptor/WebSocketInterceptor.java
@@ -30,6 +30,16 @@ public class WebSocketInterceptor implements ChannelInterceptor {
 		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
 		if (accessor.getCommand() == StompCommand.CONNECT) {
+			return message;
+		}
+
+		if (accessor.getCommand() == StompCommand.SUBSCRIBE || accessor.getCommand() == StompCommand.SEND) {
+			String destination = accessor.getDestination();
+
+			if (destination != null && destination.startsWith("/sub/session")) {
+				return message;
+			}
+
 			String accessorFirstNativeHeader = accessor.getFirstNativeHeader(HttpHeaders.AUTHORIZATION);
 			String accessToken = accessorFirstNativeHeader.substring(BEARER_PREFIX.length());
 

--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/chat")
+@RequestMapping("/api/v1/chat")
 public class ChatController {
 	private final ChatService chatService;
 

--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -3,6 +3,11 @@ package eightplusone.bit.fit.domain.chat.controller;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import eightplusone.bit.fit.domain.chat.dto.ChatMessageDto;
 import eightplusone.bit.fit.domain.chat.service.ChatService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -19,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/chat")
+@Tag(name = "Chat API", description = "채팅 관련 API")
 public class ChatController {
 	private final ChatService chatService;
 
@@ -26,44 +32,60 @@ public class ChatController {
 		this.chatService = chatService;
 	}
 
-	// Redis 로 발행
+	@Operation(summary = "메시지 전송", description = "특정 채팅 세션에 메시지를 전송합니다.")
 	@MessageMapping("/chat/{sessionId}")
-	public void sendMessage(@DestinationVariable("sessionId") String sessionId,
+	public void sendMessage(
+		@Parameter(description = "채팅 세션 ID", example = "1234") @DestinationVariable("sessionId") String sessionId,
 		@Payload ChatMessageDto message,
-		@Header("User-Id") String userId) throws JsonProcessingException {
+		@Parameter(description = "사용자 ID", example = "user123") @Header("User-Id") String userId
+	) throws JsonProcessingException {
 		chatService.sendMessage(message, userId, sessionId);
 	}
 
-	// 특정 채팅방의 최근 메시지 조회
+	@Operation(summary = "최근 메시지 조회", description = "특정 채팅방의 최근 메시지를 조회합니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "성공적으로 메시지를 반환함")
+	})
 	@GetMapping("/{sessionId}/messages")
-	public ResponseEntity<List<Object>> getRecentMessages(@PathVariable String sessionId) {
+	public ResponseEntity<List<Object>> getRecentMessages(
+		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable String sessionId
+	) {
 		List<Object> messages = chatService.getRecentMessages(sessionId);
 		return ResponseEntity.ok(messages);
 	}
 
-	// 특정 채팅방 데이터 삭제 (강연 종료 후)
+	@Operation(summary = "채팅 데이터 삭제", description = "특정 채팅방의 데이터를 삭제합니다. (강연 종료 후)")
 	@DeleteMapping("/{sessionId}/clear")
-	public ResponseEntity<String> clearChat(@PathVariable String sessionId) {
+	public ResponseEntity<String> clearChat(
+		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable String sessionId
+	) {
 		chatService.clearChat(sessionId);
 		return ResponseEntity.ok("Chat history cleared for session: " + sessionId);
 	}
 
-	// 좋아요 추가
+	@Operation(summary = "메시지 좋아요", description = "특정 메시지에 좋아요를 추가합니다.")
 	@PostMapping("/like/{messageId}")
-	public void likeMessage(@PathVariable String messageId, @RequestParam String userId) {
+	public void likeMessage(
+		@Parameter(description = "메시지 ID", example = "msg123") @PathVariable String messageId,
+		@Parameter(description = "사용자 ID", example = "user123") @RequestParam String userId
+	) {
 		chatService.likeMessage(userId, messageId);
 	}
 
-	// 좋아요 취소
+	@Operation(summary = "메시지 좋아요 취소", description = "특정 메시지의 좋아요를 취소합니다.")
 	@PostMapping("/unlike/{messageId}")
-	public void unlikeMessage(@PathVariable String messageId, @RequestParam String userId) {
+	public void unlikeMessage(
+		@Parameter(description = "메시지 ID", example = "msg123") @PathVariable String messageId,
+		@Parameter(description = "사용자 ID", example = "user123") @RequestParam String userId
+	) {
 		chatService.unlikeMessage(userId, messageId);
 	}
 
-	// 특정 세션의 QUESTION 메시지를 좋아요 순으로 정렬하여 반환
+	@Operation(summary = "질문 메시지 정렬", description = "특정 세션의 질문 메시지를 좋아요 순으로 정렬하여 반환합니다.")
 	@GetMapping("/questions/{sessionId}")
-	public List<ChatMessageDto> getSortedQuestions(@PathVariable String sessionId) {
+	public List<ChatMessageDto> getSortedQuestions(
+		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable String sessionId
+	) {
 		return chatService.getSortedQuestionMessages(sessionId);
 	}
-
 }

--- a/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
@@ -9,19 +9,25 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class ChatMessageDto {
+	private String messageId;
 	private ChatCategory category;
 	private String message;
 	private String name;
 
-	@JsonCreator
-	public ChatMessageDto(@JsonProperty("category") ChatCategory category,
-		@JsonProperty("message") String message) {
-		this.category = category;
-		this.message = message;
-	}
+	// @JsonCreator
+	// public ChatMessageDto(@JsonProperty("category") ChatCategory category,
+	// 	@JsonProperty("message") String message) {
+	// 	this.category = category;
+	// 	this.message = message;
+	// }
 
 	@JsonCreator
-	public ChatMessageDto(ChatCategory category, String message, String name) {
+	public ChatMessageDto(
+		@JsonProperty("messageId") String messageId,
+		@JsonProperty("category") ChatCategory category,
+		@JsonProperty("message") String message,
+		@JsonProperty("name") String name) {
+		this.messageId = messageId;
 		this.category = category;
 		this.message = message;
 		this.name = name;

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -129,7 +129,7 @@ public class ChatService {
 		topLikedMessages.addAll(messages);
 
 		return topLikedMessages.stream()
-			.map(msg -> new ChatMessageDto(msg.getCategory(), msg.getMessage(),
+			.map(msg -> new ChatMessageDto(msg.getMessageId(), msg.getCategory(), msg.getMessage(),
 				userRedisRepository.getUserName(msg.getUserId())))
 			.collect(Collectors.toList());
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -120,8 +120,19 @@ public class ChatService {
 			.filter(msg -> msg.getCategory() == ChatCategory.QUESTION)
 			.collect(Collectors.toList());
 
+		// 💡 가져온 메시지 개수 확인 로그
+		log.info("💬 세션 [{}]에서 가져온 메시지 개수: {}", sessionId, messages.size());
+
 		List<ChatMessage> topLikedMessages = messages.stream()
-			.sorted((m1, m2) -> Integer.compare(getLikeCount(m2.getMessageId()), getLikeCount(m1.getMessageId())))
+			// .sorted((m1, m2) -> Integer.compare(getLikeCount(m2.getMessageId()), getLikeCount(m1.getMessageId())))
+			.sorted((m1, m2) -> {
+				int likeCount1 = getLikeCount(m1.getMessageId());
+				int likeCount2 = getLikeCount(m2.getMessageId());
+
+				log.info("💡 정렬 중: {} ({}개) vs {} ({}개)", m1.getMessageId(), likeCount1, m2.getMessageId(), likeCount2);
+
+				return Integer.compare(likeCount2, likeCount1); // 내림차순 정렬
+			})
 			.limit(3)
 			.collect(Collectors.toList());
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -1,14 +1,12 @@
 package eightplusone.bit.fit.domain.session.controller;
 
+import eightplusone.bit.fit.domain.session.service.SessionService;
 import java.util.Map;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RestController;
-
-import eightplusone.bit.fit.domain.session.service.SessionService;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +20,6 @@ public class SessionWebSocketController {
 	public void broadcastSessionUpdate() {
 		Map<Integer, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
 		log.info("send congestion data : {}", sessionData.toString());
-		messagingTemplate.convertAndSend("/sub/ws-room", sessionData);
+		messagingTemplate.convertAndSend("/sub/ws", sessionData);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionWebSocketController.java
@@ -1,12 +1,14 @@
 package eightplusone.bit.fit.domain.session.controller;
 
-import eightplusone.bit.fit.domain.session.service.SessionService;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.session.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,6 +22,6 @@ public class SessionWebSocketController {
 	public void broadcastSessionUpdate() {
 		Map<Integer, Map<String, Object>> sessionData = sessionService.getUpdatedSessionData();
 		log.info("send congestion data : {}", sessionData.toString());
-		messagingTemplate.convertAndSend("/sub/ws", sessionData);
+		messagingTemplate.convertAndSend("/sub/session", sessionData);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -1,18 +1,16 @@
 package eightplusone.bit.fit.domain.session.service;
 
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -86,7 +84,7 @@ public class SessionService {
 
 		if (!newLevel.equals(previousLevel)) {
 			hashOps.put(SESSION_CONGESTION_KEY, audioChannel.toString(), newLevel);
-			redisTemplate.convertAndSend("/sub/ws-room", Map.of(
+			redisTemplate.convertAndSend("/sub/ws", Map.of(
 				"sessionId", audioChannel,
 				"percent", percent,
 				"level", newLevel

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -1,16 +1,18 @@
 package eightplusone.bit.fit.domain.session.service;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import jakarta.persistence.EntityNotFoundException;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.HashOperations;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -84,7 +86,7 @@ public class SessionService {
 
 		if (!newLevel.equals(previousLevel)) {
 			hashOps.put(SESSION_CONGESTION_KEY, audioChannel.toString(), newLevel);
-			redisTemplate.convertAndSend("/sub/ws", Map.of(
+			redisTemplate.convertAndSend("/sub/session", Map.of(
 				"sessionId", audioChannel,
 				"percent", percent,
 				"level", newLevel

--- a/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/WebSocketConfig.java
@@ -1,14 +1,13 @@
 package eightplusone.bit.fit.global.config;
 
+import eightplusone.bit.fit.domain.auth.interceptor.WebSocketInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
-
-import eightplusone.bit.fit.domain.auth.interceptor.WebSocketInterceptor;
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -25,8 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/ws-chat").setAllowedOriginPatterns("*");
-		registry.addEndpoint("/ws-room").setAllowedOriginPatterns("*");
+		registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
 	}
 
 	@Override

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -1,8 +1,7 @@
 package eightplusone.bit.fit.global.enums;
 
-import org.springframework.http.HttpMethod;
-
 import lombok.Getter;
+import org.springframework.http.HttpMethod;
 
 @Getter
 public enum ApiEndpoint {
@@ -12,9 +11,8 @@ public enum ApiEndpoint {
 		"/actuator/**",
 		"/v3/**",
 		"/call",
-		"/ws-chat",
-		"/ws-chat/**",
-		"/ws-room"
+		"/ws",
+		"/ws/**",
 	}),
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -51,7 +51,7 @@ public class ChatServiceTest {
 		userId = "test-user";
 		messageId = "test-message-id";
 
-		testMessageDto = new ChatMessageDto(ChatCategory.GENERAL, "테스트 메시지", "테스터");
+		testMessageDto = new ChatMessageDto("msg-001", ChatCategory.GENERAL, "테스트 메시지", "테스터");
 
 		testMessage = ChatMessage.builder()
 			.sessionId(sessionId)

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -4,10 +4,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -15,9 +16,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-
-import eightplusone.bit.fit.domain.session.entity.Session;
-import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 
 class SessionServiceTest {
 
@@ -103,7 +101,7 @@ class SessionServiceTest {
 
 		// Then
 		verify(hashOperations).put("session_congestion", audioChannel.toString(), newLevel);
-		verify(redisTemplate).convertAndSend(eq("/sub/ws-room"), argThat(message -> {
+		verify(redisTemplate).convertAndSend(eq("/sub/ws"), argThat(message -> {
 			Map<String, Object> msg = (Map<String, Object>)message;
 			return msg.get("sessionId").equals(audioChannel) &&
 				msg.get("percent").equals(percent) &&

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -4,11 +4,10 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
-import eightplusone.bit.fit.domain.session.entity.Session;
-import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -16,6 +15,9 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 
 class SessionServiceTest {
 
@@ -101,7 +103,7 @@ class SessionServiceTest {
 
 		// Then
 		verify(hashOperations).put("session_congestion", audioChannel.toString(), newLevel);
-		verify(redisTemplate).convertAndSend(eq("/sub/ws"), argThat(message -> {
+		verify(redisTemplate).convertAndSend(eq("/sub/session"), argThat(message -> {
 			Map<String, Object> msg = (Map<String, Object>)message;
 			return msg.get("sessionId").equals(audioChannel) &&
 				msg.get("percent").equals(percent) &&


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#43 ]

### 로컬 병합
X

### 변경 사항
1. ChatController의 엔드포인트를 /api/v1 으로 시작하도록 통일했습니다.
2. 채팅과 혼잡도에서 사용하던 웹소켓 연결 엔드포인트 /ws-chat 과 /ws-room을 /ws로 통일하였습니다.

