### PR TITLE
[#40] 미리담기 및 조회 기능

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/mysession/controller/MySessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/controller/MySessionController.java
@@ -1,0 +1,42 @@
+package eightplusone.bit.fit.domain.mysession.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.mysession.dto.MySessionRegisterRequestDto;
+import eightplusone.bit.fit.domain.mysession.service.MySessionService;
+import eightplusone.bit.fit.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users/sessions")
+public class MySessionController {
+
+	private final MySessionService mySessionService;
+
+	@Operation(summary = "세션 미리 담기 요청", description = "**성공 응답 데이터:**  null")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "세션 미리 담기 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
+		@ApiResponse(responseCode = "404", description = "해당 세션을 찾을 수 없습니다."),
+		@ApiResponse(responseCode = "500", description = "서버에 오류가 발생했습니다."),
+	})
+	@PostMapping
+	public ResponseEntity<ResponseDto<Object>> register(
+		@RequestBody MySessionRegisterRequestDto mySessionRegisterRequestDto) {
+		mySessionService.registerMySession(SecurityContextHolder.getContext().getAuthentication().getName(),
+			mySessionRegisterRequestDto.getSessionId());
+		return ResponseEntity.status(CREATED).body(ResponseDto.success(CREATED, "세션 미리 담기 등록 성공", null));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/controller/MySessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/controller/MySessionController.java
@@ -2,13 +2,17 @@ package eightplusone.bit.fit.domain.mysession.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import eightplusone.bit.fit.domain.mysession.dto.MySessionListResponseDto;
 import eightplusone.bit.fit.domain.mysession.dto.MySessionRegisterRequestDto;
 import eightplusone.bit.fit.domain.mysession.service.MySessionService;
 import eightplusone.bit.fit.global.dto.ResponseDto;
@@ -26,17 +30,31 @@ public class MySessionController {
 
 	@Operation(summary = "세션 미리 담기 요청", description = "**성공 응답 데이터:**  null")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "200", description = "세션 미리 담기 성공"),
+		@ApiResponse(responseCode = "201", description = "세션 미리 담기 성공"),
 		@ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
 		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
 		@ApiResponse(responseCode = "404", description = "해당 세션을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "500", description = "서버에 오류가 발생했습니다."),
 	})
 	@PostMapping
-	public ResponseEntity<ResponseDto<Object>> register(
+	public ResponseEntity<ResponseDto<Object>> registerSession(
 		@RequestBody MySessionRegisterRequestDto mySessionRegisterRequestDto) {
 		mySessionService.registerMySession(SecurityContextHolder.getContext().getAuthentication().getName(),
 			mySessionRegisterRequestDto.getSessionId());
 		return ResponseEntity.status(CREATED).body(ResponseDto.success(CREATED, "세션 미리 담기 등록 성공", null));
+	}
+
+	@Operation(summary = "미리 담은 세션 스케줄 조회", description = "**성공 응답 데이터:**  미리 담은 세션 리스트")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "미리 담은 세션 스케쥴 조회 성공"),
+		@ApiResponse(responseCode = "400", description = "잘못된 입력 값"),
+		@ApiResponse(responseCode = "401", description = "유효한 토큰이 아닙니다."),
+		@ApiResponse(responseCode = "500", description = "서버에 오류가 발생했습니다."),
+	})
+	@GetMapping
+	public ResponseEntity<ResponseDto<List<MySessionListResponseDto>>> getRegisteredSessions() {
+		return ResponseEntity.status(OK).body(ResponseDto.success(OK, "미리 담은 세션 스케쥴 조회 성공",
+			mySessionService.findRegisteredMySessions(
+				SecurityContextHolder.getContext().getAuthentication().getName())));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionListResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionListResponseDto.java
@@ -1,0 +1,56 @@
+package eightplusone.bit.fit.domain.mysession.dto;
+
+import java.time.format.DateTimeFormatter;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Schema(name = "MySessionListResponseDto: 미리 담기된 강연 스케쥴 Dto")
+public class MySessionListResponseDto {
+	@Schema(description = "강연 식별자", example = "1")
+	private final Long sessionId;
+	@Schema(description = "강연 제목", example = "프론트엔드 마스터하기")
+	private final String title;
+	@Schema(description = "강연 이미지", example = "image.png")
+	private final String sessionImage;
+	@Schema(description = "강연 요약", example = "JS를 잘하는법")
+	private final String summary;
+	@Schema(description = "강연 시작 시간", example = "202504020950")
+	private final String startTime;
+	@Schema(description = "강연 종료 시간", example = "202504021050")
+	private final String endTime;
+	@Schema(description = "최대 수용 인원", example = "70")
+	private final Integer standardCount;
+	@Schema(description = "오디오 채널방 번호", example = "1")
+	private final Integer audioChannel;
+
+	@Builder
+	private MySessionListResponseDto(Long sessionId, String title, String sessionImage, String summary,
+		String startTime, String endTime, Integer standardCount, Integer audioChannel) {
+		this.sessionId = sessionId;
+		this.title = title;
+		this.sessionImage = sessionImage;
+		this.summary = summary;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.standardCount = standardCount;
+		this.audioChannel = audioChannel;
+	}
+
+	public static MySessionListResponseDto from(Session session) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
+		return MySessionListResponseDto.builder()
+			.sessionId(session.getSessionId())
+			.title(session.getTitle())
+			.sessionImage(session.getSessionImage())
+			.summary(session.getSummary())
+			.startTime(session.getStartTime().format(formatter))
+			.endTime(session.getEndTime().format(formatter))
+			.standardCount(session.getStandardCount())
+			.audioChannel(session.getAudioChannel())
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionRegisterRequestDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionRegisterRequestDto.java
@@ -1,0 +1,21 @@
+package eightplusone.bit.fit.domain.mysession.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "MySessionRegisterRequestDto: 세션 미리 담기 요청 Dto")
+public class MySessionRegisterRequestDto {
+	@Min(value = 1, message = "세션 식별자는 1 이상이어야 합니다.")
+	@NotNull(message = "세션 식별자가 입력되지 않았습니다.")
+	@Schema(description = "세션 식별자", example = "1")
+	private Long sessionId;
+
+	public MySessionRegisterRequestDto(Long sessionId) {
+		this.sessionId = sessionId;
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/entity/MySession.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/entity/MySession.java
@@ -1,0 +1,73 @@
+package eightplusone.bit.fit.domain.mysession.entity;
+
+import static jakarta.persistence.FetchType.*;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "my_session")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MySession {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "my_session_id")
+	private Long id;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "type", length = 20, nullable = false)
+	private MySessionType type;
+
+	@JsonIgnore
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@JsonIgnore
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "session_id")
+	private Session session;
+
+	@Builder
+	private MySession(MySessionType type, User user, Session session) {
+		this.type = type;
+		setSession(session);
+		setUser(user);
+	}
+
+	public static MySession register(User user, Session session) {
+		return MySession.builder()
+			.type(MySessionType.REGISTER)
+			.user(user)
+			.session(session)
+			.build();
+	}
+
+	private void setSession(Session session) {
+		this.session = session;
+		session.getMySessions().add(this);
+	}
+
+	private void setUser(User user) {
+		this.user = user;
+		user.getMySessions().add(this);
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/enums/MySessionType.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/enums/MySessionType.java
@@ -1,0 +1,6 @@
+package eightplusone.bit.fit.domain.mysession.enums;
+
+public enum MySessionType {
+	REGISTER,
+	LIKE
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/repository/MySessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/repository/MySessionRepository.java
@@ -1,15 +1,16 @@
 package eightplusone.bit.fit.domain.mysession.repository;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
+import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
 
 public interface MySessionRepository extends JpaRepository<MySession, Long> {
 	@Query(""" 
-		select ms from MySession ms left join fetch ms.session where ms.user.id = :userId
+		select ms from MySession ms left join fetch ms.session where ms.user.id = :userId and ms.type = :type
 		""")
-	Optional<MySession> findSessionByUserId(Long userId);
+	List<MySession> findSessionsByUserIdAndType(Long userId, MySessionType type);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/repository/MySessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/repository/MySessionRepository.java
@@ -1,0 +1,15 @@
+package eightplusone.bit.fit.domain.mysession.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
+
+public interface MySessionRepository extends JpaRepository<MySession, Long> {
+	@Query(""" 
+		select ms from MySession ms left join fetch ms.session where ms.user.id = :userId
+		""")
+	Optional<MySession> findSessionByUserId(Long userId);
+}

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
@@ -1,9 +1,14 @@
 package eightplusone.bit.fit.domain.mysession.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import eightplusone.bit.fit.domain.mysession.dto.MySessionListResponseDto;
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
+import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
 import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
@@ -28,5 +33,13 @@ public class MySessionService {
 		Session session = sessionRepository.findById(sessionId)
 			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
 		mySessionRepository.save(MySession.register(user, session));
+	}
+
+	public List<MySessionListResponseDto> findRegisteredMySessions(String email) {
+		User user = userRepository.findLoginUserByEmail(email);
+		return mySessionRepository.findSessionsByUserIdAndType(user.getId(), MySessionType.REGISTER)
+			.stream()
+			.map(mySession -> MySessionListResponseDto.from(mySession.getSession()))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
@@ -1,0 +1,32 @@
+package eightplusone.bit.fit.domain.mysession.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
+import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.user.entity.User;
+import eightplusone.bit.fit.domain.user.repository.UserRepository;
+import eightplusone.bit.fit.global.exception.CustomException;
+import eightplusone.bit.fit.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MySessionService {
+
+	private final MySessionRepository mySessionRepository;
+	private final UserRepository userRepository;
+	private final SessionRepository sessionRepository;
+
+	@Transactional
+	public void registerMySession(String email, Long sessionId) {
+		User user = userRepository.findLoginUserByEmail(email);
+		Session session = sessionRepository.findById(sessionId)
+			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+		mySessionRepository.save(MySession.register(user, session));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -1,12 +1,17 @@
 package eightplusone.bit.fit.domain.session.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -38,4 +43,7 @@ public class Session {
 
 	@Column(nullable = false)
 	private Integer audioChannel;
+
+	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<MySession> mySessions = new ArrayList<>();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -13,11 +13,14 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "sessions")
+@NoArgsConstructor
 public class Session {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,4 +49,16 @@ public class Session {
 
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MySession> mySessions = new ArrayList<>();
+
+	@Builder
+	public Session(String title, String sessionImage, String summary, LocalDateTime startTime, LocalDateTime endTime,
+		Integer standardCount, Integer audioChannel) {
+		this.title = title;
+		this.sessionImage = sessionImage;
+		this.summary = summary;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.standardCount = standardCount;
+		this.audioChannel = audioChannel;
+	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/entity/User.java
@@ -1,7 +1,12 @@
 package eightplusone.bit.fit.domain.user.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import eightplusone.bit.fit.domain.auth.enums.Role;
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import eightplusone.bit.fit.global.base.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,6 +14,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,6 +55,9 @@ public class User extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "role", length = 20, nullable = false)
 	private Role role;
+
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<MySession> mySessions = new ArrayList<>();
 
 	@Builder
 	private User(String email, String name, String provider, String job, Integer years, String interests, Role role) {

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -30,7 +30,8 @@ public enum ApiEndpoint {
 	AUTHENTICATED_POST(HttpMethod.POST, new String[] {
 		"/api/v1/auth/logout",
 		"/api/v1/enter/checkin",
-		"/api/v1/enter/checkout"
+		"/api/v1/enter/checkout",
+		"/api/v1/users/sessions"
 	}),
 
 	AUTHENTICATED_PUT(HttpMethod.PUT, new String[] {

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -24,7 +24,8 @@ public enum ApiEndpoint {
 
 	AUTHENTICATED_GET(HttpMethod.GET, new String[] {
 		"/api/v1/users/account",
-		"/api/v1/users/profile"
+		"/api/v1/users/profile",
+		"/api/v1/users/sessions"
 	}),
 
 	AUTHENTICATED_POST(HttpMethod.POST, new String[] {

--- a/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
@@ -3,6 +3,8 @@ package eightplusone.bit.fit.domain.mysession.service;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,8 +18,6 @@ import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
-import eightplusone.bit.fit.global.exception.CustomException;
-import eightplusone.bit.fit.global.exception.ErrorCode;
 import eightplusone.bit.fit.support.fixture.SessionFixture;
 import eightplusone.bit.fit.support.fixture.UserFixture;
 
@@ -47,8 +47,9 @@ class MySessionServiceTest {
 		mySessionService.registerMySession(user.getEmail(), session.getSessionId());
 
 		//then
-		MySession mySession = mySessionRepository.findSessionByUserId(user.getId())
-			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+		List<MySession> mySessions = mySessionRepository.findSessionsByUserIdAndType(user.getId(),
+			MySessionType.REGISTER);
+		MySession mySession = mySessions.get(0);
 		assertAll(
 			() -> assertThat(mySession.getType()).isEqualTo(MySessionType.REGISTER),
 			() -> assertThat(mySession.getSession().getSessionId()).isEqualTo(session.getSessionId()),

--- a/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
@@ -1,0 +1,63 @@
+package eightplusone.bit.fit.domain.mysession.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
+import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
+import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.user.entity.User;
+import eightplusone.bit.fit.domain.user.repository.UserRepository;
+import eightplusone.bit.fit.global.exception.CustomException;
+import eightplusone.bit.fit.global.exception.ErrorCode;
+import eightplusone.bit.fit.support.fixture.SessionFixture;
+import eightplusone.bit.fit.support.fixture.UserFixture;
+
+@SpringBootTest
+@Transactional
+class MySessionServiceTest {
+
+	@Autowired
+	MySessionService mySessionService;
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	SessionRepository sessionRepository;
+	@Autowired
+	MySessionRepository mySessionRepository;
+
+	@Test
+	@DisplayName("사용자는 강의 미리 담기를 한다")
+	void register() {
+		//given
+		User userFixture = UserFixture.USER_FIXTURE_1.createUser();
+		User user = userRepository.save(userFixture);
+
+		Session sessionFixture = SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession();
+		Session session = sessionRepository.save(sessionFixture);
+		//when
+		mySessionService.registerMySession(user.getEmail(), session.getSessionId());
+
+		//then
+		MySession mySession = mySessionRepository.findSessionByUserId(user.getId())
+			.orElseThrow(() -> new CustomException(ErrorCode.RESOURCE_NOT_FOUND));
+		assertAll(
+			() -> assertThat(mySession.getType()).isEqualTo(MySessionType.REGISTER),
+			() -> assertThat(mySession.getSession().getSessionId()).isEqualTo(session.getSessionId()),
+			() -> assertThat(mySession.getSession().getTitle()).isEqualTo(session.getTitle()),
+			() -> assertThat(mySession.getSession().getSummary()).isEqualTo(session.getSummary()),
+			() -> assertThat(mySession.getSession().getStartTime()).isEqualTo(session.getStartTime()),
+			() -> assertThat(mySession.getSession().getEndTime()).isEqualTo(session.getEndTime()),
+			() -> assertThat(mySession.getSession().getStandardCount()).isEqualTo(session.getStandardCount()),
+			() -> assertThat(mySession.getSession().getAudioChannel()).isEqualTo(session.getAudioChannel())
+		);
+	}
+}

--- a/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
@@ -1,8 +1,9 @@
 package eightplusone.bit.fit.domain.mysession.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import eightplusone.bit.fit.domain.mysession.dto.MySessionListResponseDto;
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
 import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
@@ -59,6 +61,76 @@ class MySessionServiceTest {
 			() -> assertThat(mySession.getSession().getEndTime()).isEqualTo(session.getEndTime()),
 			() -> assertThat(mySession.getSession().getStandardCount()).isEqualTo(session.getStandardCount()),
 			() -> assertThat(mySession.getSession().getAudioChannel()).isEqualTo(session.getAudioChannel())
+		);
+	}
+
+	@Test
+	@DisplayName("미리 담기를 진행한 강연 정보를 조회한다")
+	void getRegisteredSessions() {
+		//given
+		User user = userRepository.save(UserFixture.USER_FIXTURE_1.createUser());
+
+		Session session1 = sessionRepository.save(SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession());
+		Session session2 = sessionRepository.save(SessionFixture.SESSION_STAGE_2_FIXTURE_2.createSession());
+		Session session3 = sessionRepository.save(SessionFixture.SESSION_STAGE_3_FIXTURE_3.createSession());
+		Session session4 = sessionRepository.save(SessionFixture.SESSION_STAGE_4_FIXTURE_1.createSession());
+
+		mySessionRepository.save(MySession.register(user, session1));
+		mySessionRepository.save(MySession.register(user, session2));
+		mySessionRepository.save(MySession.register(user, session3));
+		mySessionRepository.save(MySession.register(user, session4));
+
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
+
+		//when
+		List<MySessionListResponseDto> mySessionListResponseDto = mySessionService.findRegisteredMySessions(
+			user.getEmail());
+
+		//then
+		assertAll(
+			() -> assertThat(mySessionListResponseDto.get(0).getSessionId()).isEqualTo(session1.getSessionId()),
+			() -> assertThat(mySessionListResponseDto.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(mySessionListResponseDto.get(0).getSummary()).isEqualTo(session1.getSummary()),
+			() -> assertThat(mySessionListResponseDto.get(0).getSessionImage()).isEqualTo(session1.getSessionImage()),
+			() -> assertThat(mySessionListResponseDto.get(0).getStandardCount()).isEqualTo(session1.getStandardCount()),
+			() -> assertThat(mySessionListResponseDto.get(0).getAudioChannel()).isEqualTo(session1.getAudioChannel()),
+			() -> assertThat(mySessionListResponseDto.get(0).getStartTime()).isEqualTo(
+				session1.getStartTime().format(formatter)),
+			() -> assertThat(mySessionListResponseDto.get(0).getEndTime()).isEqualTo(
+				session1.getEndTime().format(formatter)),
+
+			() -> assertThat(mySessionListResponseDto.get(1).getSessionId()).isEqualTo(session2.getSessionId()),
+			() -> assertThat(mySessionListResponseDto.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(mySessionListResponseDto.get(1).getSummary()).isEqualTo(session2.getSummary()),
+			() -> assertThat(mySessionListResponseDto.get(1).getSessionImage()).isEqualTo(session2.getSessionImage()),
+			() -> assertThat(mySessionListResponseDto.get(1).getStandardCount()).isEqualTo(session2.getStandardCount()),
+			() -> assertThat(mySessionListResponseDto.get(1).getAudioChannel()).isEqualTo(session2.getAudioChannel()),
+			() -> assertThat(mySessionListResponseDto.get(1).getStartTime()).isEqualTo(
+				session2.getStartTime().format(formatter)),
+			() -> assertThat(mySessionListResponseDto.get(1).getEndTime()).isEqualTo(
+				session2.getEndTime().format(formatter)),
+
+			() -> assertThat(mySessionListResponseDto.get(2).getSessionId()).isEqualTo(session3.getSessionId()),
+			() -> assertThat(mySessionListResponseDto.get(2).getTitle()).isEqualTo(session3.getTitle()),
+			() -> assertThat(mySessionListResponseDto.get(2).getSummary()).isEqualTo(session3.getSummary()),
+			() -> assertThat(mySessionListResponseDto.get(2).getSessionImage()).isEqualTo(session3.getSessionImage()),
+			() -> assertThat(mySessionListResponseDto.get(2).getStandardCount()).isEqualTo(session3.getStandardCount()),
+			() -> assertThat(mySessionListResponseDto.get(2).getAudioChannel()).isEqualTo(session3.getAudioChannel()),
+			() -> assertThat(mySessionListResponseDto.get(2).getStartTime()).isEqualTo(
+				session3.getStartTime().format(formatter)),
+			() -> assertThat(mySessionListResponseDto.get(2).getEndTime()).isEqualTo(
+				session3.getEndTime().format(formatter)),
+
+			() -> assertThat(mySessionListResponseDto.get(3).getSessionId()).isEqualTo(session4.getSessionId()),
+			() -> assertThat(mySessionListResponseDto.get(3).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(mySessionListResponseDto.get(3).getSummary()).isEqualTo(session4.getSummary()),
+			() -> assertThat(mySessionListResponseDto.get(3).getSessionImage()).isEqualTo(session4.getSessionImage()),
+			() -> assertThat(mySessionListResponseDto.get(3).getStandardCount()).isEqualTo(session4.getStandardCount()),
+			() -> assertThat(mySessionListResponseDto.get(3).getAudioChannel()).isEqualTo(session4.getAudioChannel()),
+			() -> assertThat(mySessionListResponseDto.get(3).getStartTime()).isEqualTo(
+				session4.getStartTime().format(formatter)),
+			() -> assertThat(mySessionListResponseDto.get(3).getEndTime()).isEqualTo(
+				session4.getEndTime().format(formatter))
 		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/support/fixture/SessionFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/SessionFixture.java
@@ -1,0 +1,82 @@
+package eightplusone.bit.fit.support.fixture;
+
+import java.time.LocalDateTime;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import lombok.Getter;
+
+@Getter
+public enum SessionFixture {
+	/**
+	 * 1부 세션 1,2,3
+	 */
+	SESSION_STAGE_1_FIXTURE_1("1부 세션1 09:50-10:50", "백엔드 잘하는 법", "image1_1.png",
+		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 100, 2),
+	SESSION_STAGE_1_FIXTURE_2("1부 세션2 09:50-10:50", "프론트엔드 마스터하기", "image1_2.png",
+		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 50, 1),
+	SESSION_STAGE_1_FIXTURE_3("1부 세션3 09:50-10:50", "데이터베이스 성능 최적화", "image1_3.png",
+		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 70, 3),
+
+	/**
+	 * 2부 세션 1,2,3
+	 */
+	SESSION_STAGE_2_FIXTURE_1("2부 세션1 11:50-12:50", "백엔드 잘하는 법", "image2_1.png",
+		LocalDateTime.of(2024, 4, 2, 11, 50), LocalDateTime.of(2024, 4, 2, 12, 50), 100, 2),
+	SESSION_STAGE_2_FIXTURE_2("2부 세션2 11:50-12:50", "프론트엔드 마스터하기", "image2_2.png",
+		LocalDateTime.of(2024, 4, 2, 11, 50), LocalDateTime.of(2024, 4, 2, 12, 50), 50, 1),
+	SESSION_STAGE_2_FIXTURE_3("2부 세션3 11:50-12:50", "데이터베이스 성능 최적화", "image2_3.png",
+		LocalDateTime.of(2024, 4, 2, 11, 50), LocalDateTime.of(2024, 4, 2, 12, 50), 70, 3),
+
+	/**
+	 * 3부 세션 1,2,3
+	 */
+	SESSION_STAGE_3_FIXTURE_1("3부 세션1 01:50-02:50", "백엔드 잘하는 법", "image3_1.png",
+		LocalDateTime.of(2024, 4, 2, 13, 50), LocalDateTime.of(2024, 4, 2, 14, 50), 100, 2),
+	SESSION_STAGE_3_FIXTURE_2("3부 세션2 01:50-02:50", "프론트엔드 마스터하기", "image3_2.png",
+		LocalDateTime.of(2024, 4, 2, 13, 50), LocalDateTime.of(2024, 4, 2, 14, 50), 50, 1),
+	SESSION_STAGE_3_FIXTURE_3("3부 세션3 01:50-02:50", "데이터베이스 성능 최적화", "image3_3.png",
+		LocalDateTime.of(2024, 4, 2, 13, 50), LocalDateTime.of(2024, 4, 2, 14, 50), 70, 3),
+
+	/**
+	 * 4부 세션 1,2,3
+	 */
+	SESSION_STAGE_4_FIXTURE_1("4부 세션1 02:50-03:50", "백엔드 잘하는 법", "image4_1.png",
+		LocalDateTime.of(2024, 4, 2, 14, 50), LocalDateTime.of(2024, 4, 2, 15, 50), 100, 2),
+	SESSION_STAGE_4_FIXTURE_2("4부 세션2 02:50-03:50", "프론트엔드 마스터하기", "image4_2.png",
+		LocalDateTime.of(2024, 4, 2, 14, 50), LocalDateTime.of(2024, 4, 2, 15, 50), 50, 1),
+	SESSION_STAGE_4_FIXTURE_3("4부 세션3 02:50-03:50", "데이터베이스 성능 최적화", "image4_3.png",
+		LocalDateTime.of(2024, 4, 2, 14, 50), LocalDateTime.of(2024, 4, 2, 15, 50), 70, 3);
+
+	private final String title;
+	private final String sessionImage;
+	private final String summary;
+	private final LocalDateTime startTime;
+	private final LocalDateTime endTime;
+	private final Integer standardCount;
+	private final Integer audioChannel;
+
+	SessionFixture(String title, String summary, String sessionImage, LocalDateTime startTime, LocalDateTime endTime,
+		Integer standardCount,
+		Integer audioChannel) {
+		this.title = title;
+		this.sessionImage = sessionImage;
+		this.summary = summary;
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.standardCount = standardCount;
+		this.audioChannel = audioChannel;
+	}
+
+	public Session createSession() {
+		return Session.builder()
+			.title(title)
+			.sessionImage(sessionImage)
+			.summary(summary)
+			.startTime(startTime)
+			.endTime(endTime)
+			.standardCount(standardCount)
+			.audioChannel(audioChannel)
+			.build();
+	}
+}
+


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#40 ]


### 변경 사항
- 세션 미리담기 기능 추가
- 스케쥴을 위한 미리담기한 세션 리스트 조회 기능 추가

### 테스트 결과

MySessionService테스트
![스크린샷 2025-03-18 오전 10 22 05](https://github.com/user-attachments/assets/3d798e29-9318-486a-95c2-46ec10d1c4b6)


![스크린샷 2025-03-18 오전 10 12 09](https://github.com/user-attachments/assets/92c8d806-76f8-40e6-a0fe-d8427aa8ba2c)

세션 미리담기 API 테스트

![스크린샷 2025-03-18 오전 10 12 55](https://github.com/user-attachments/assets/315c3839-003b-4c6b-ab00-3214a79c201d)

미리담기한 세션 리스트 조회 API 테스트
