### PR TITLE
[#35] cors 인증 헤더 값 상수로 수정

### DIFF
--- a/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
 				configuration.setAllowedHeaders(ALLOWED_HEADERS);
 				configuration.setMaxAge(MAX_AGE);
 				configuration.setExposedHeaders(Collections.singletonList(HttpHeaders.SET_COOKIE));
-				configuration.setExposedHeaders(Collections.singletonList(HttpHeaders.AUTHORIZATION));
+				configuration.setExposedHeaders(Collections.singletonList(AUTHORIZATION));
 				return configuration;
 			}))
 			.csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/eightplusone/bit/fit/global/constants/CorsConstant.java
+++ b/src/main/java/eightplusone/bit/fit/global/constants/CorsConstant.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public class CorsConstant {
 
+	public static final String AUTHORIZATION = "authorization";
 	public static final List<String> ALLOWED_METHODS = List.of("GET", "POST", "PUT", "DELETE", "OPTIONS");
 	public static final List<String> ALLOWED_HEADERS = List.of("X-Requested-With", "Content-Type", "Accept");
 	public static final boolean ALLOWED_CREDENTIALS = true;


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#35]

### 변경 사항
- cors 필터의 Authorization은 소문자로 기입해야 인식된다는것을 파악하고 상수로 처리하여 수정했습니다.

### 테스트 결과
![스크린샷 2025-03-19 오후 2 23 40](https://github.com/user-attachments/assets/0bc9984c-cb8a-48db-9f6c-0c8f5c9c4cc4)
프론트와 인증 헤더를 통한 통신 테스트

