### PR TITLE
[#41] 강연 전체 조회 및 필터링 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     testAnnotationProcessor 'org.projectlombok:lombok'
     //swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    // querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
@@ -69,4 +74,18 @@ tasks.named("processResources") {
 
 tasks.named("build") {
     dependsOn("copyPrivate")
+}
+
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+    main.java.srcDirs += [generated]
+}
+
+clean {
+    delete file(generated)
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/EnterController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/EnterController.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/enter")
 @RequiredArgsConstructor
-public class SessionController {
+public class EnterController {
 
 	private final SessionService sessionService;
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.service.SessionService;
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -30,8 +31,9 @@ public class SessionController {
 		@ApiResponse(responseCode = "200", description = "세션 전체 조회 성공"),
 	})
 	@GetMapping("/all")
-	public ResponseEntity<ResponseDto<Page<SessionListResponseDto>>> all(@PageableDefault(size = 9) Pageable pageable) {
+	public ResponseEntity<ResponseDto<Page<SessionListResponseDto>>> all(@PageableDefault(size = 9) Pageable pageable,
+		TagResponseDto dto) {
 		return ResponseEntity.status(OK)
-			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList(pageable)));
+			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList(pageable, dto)));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -1,0 +1,36 @@
+package eightplusone.bit.fit.domain.session.controller;
+
+import static org.springframework.http.HttpStatus.*;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
+import eightplusone.bit.fit.domain.session.service.SessionService;
+import eightplusone.bit.fit.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/session")
+@RequiredArgsConstructor
+public class SessionController {
+
+	private final SessionService sessionService;
+
+	@Operation(summary = "세션 전체 조회", description = "**성공 응답 데이터:**  세션 전체 리스트")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "세션 전체 조회 성공"),
+	})
+	@GetMapping("/all")
+	public ResponseEntity<ResponseDto<List<SessionListResponseDto>>> all() {
+		return ResponseEntity.status(OK)
+			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList()));
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -2,8 +2,9 @@ package eightplusone.bit.fit.domain.session.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,8 +30,8 @@ public class SessionController {
 		@ApiResponse(responseCode = "200", description = "세션 전체 조회 성공"),
 	})
 	@GetMapping("/all")
-	public ResponseEntity<ResponseDto<List<SessionListResponseDto>>> all() {
+	public ResponseEntity<ResponseDto<Page<SessionListResponseDto>>> all(@PageableDefault(size = 9) Pageable pageable) {
 		return ResponseEntity.status(OK)
-			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList()));
+			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList(pageable)));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
@@ -1,0 +1,36 @@
+package eightplusone.bit.fit.domain.session.dto;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(name = "SessionListResponseDto: 전체 세션 조회 Dto")
+public class SessionListResponseDto {
+	@Schema(description = "", example = "")
+	private Long id;
+
+	@Schema(description = "", example = "")
+	private String title;
+
+	@Schema(description = "", example = "")
+	private String summary;
+
+	private SpeakerResponseDto speaker;
+
+	private TagResponseDto tags;
+
+	public static SessionListResponseDto from(Session session, SpeakerResponseDto speaker, TagResponseDto tags) {
+		return SessionListResponseDto.builder()
+			.id(session.getSessionId())
+			.title(session.getTitle())
+			.summary(session.getSummary())
+			.speaker(speaker)
+			.tags(tags)
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -4,9 +4,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
-import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,8 +14,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -54,6 +54,12 @@ public class Session {
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MySession> mySessions = new ArrayList<>();
 
+	@OneToOne(fetch = FetchType.LAZY)
+	private Tag tag;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Speaker speaker;
+
 	@Builder
 	public Session(String title, String sessionImage, String summary, LocalDateTime startTime, LocalDateTime endTime,
 		Integer standardCount, Integer audioChannel) {
@@ -65,10 +71,4 @@ public class Session {
 		this.standardCount = standardCount;
 		this.audioChannel = audioChannel;
 	}
-
-	@OneToOne(fetch = FetchType.LAZY)
-	private Tag tag;
-
-	@OneToOne(fetch = FetchType.LAZY)
-	private Speaker speaker;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -2,11 +2,15 @@ package eightplusone.bit.fit.domain.session.entity;
 
 import java.time.LocalDateTime;
 
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.tag.entity.Tag;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -38,4 +42,10 @@ public class Session {
 
 	@Column(nullable = false)
 	private Integer audioChannel;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Tag tag;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Speaker speaker;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -5,17 +5,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
-import eightplusone.bit.fit.domain.speaker.entity.Speaker;
-import eightplusone.bit.fit.domain.tag.entity.Tag;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,12 +49,6 @@ public class Session {
 
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MySession> mySessions = new ArrayList<>();
-
-	@OneToOne(fetch = FetchType.LAZY)
-	private Tag tag;
-
-	@OneToOne(fetch = FetchType.LAZY)
-	private Speaker speaker;
 
 	@Builder
 	public Session(String title, String sessionImage, String summary, LocalDateTime startTime, LocalDateTime endTime,

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -2,10 +2,14 @@ package eightplusone.bit.fit.domain.session.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
 	Optional<Session> findByAudioChannel(Integer audioChannel);
+
+	Page<Session> findAll(Pageable pageable);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,11 +1,16 @@
 package eightplusone.bit.fit.domain.session.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
 	Optional<Session> findByAudioChannel(Integer audioChannel);
+
+	@Query("SELECT s FROM Session s JOIN FETCH s.speaker JOIN FETCH s.tag")
+	List<Session> findAllWithSpeakerAndTag();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,16 +1,11 @@
 package eightplusone.bit.fit.domain.session.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
 public interface SessionRepository extends JpaRepository<Session, Long> {
 	Optional<Session> findByAudioChannel(Integer audioChannel);
-
-	@Query("SELECT s FROM Session s JOIN FETCH s.speaker JOIN FETCH s.tag")
-	List<Session> findAllWithSpeakerAndTag();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -8,9 +8,12 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
@@ -92,5 +95,17 @@ public class SessionService {
 				"level", newLevel
 			));
 		}
+	}
+
+	public List<SessionListResponseDto> getSessionsList() {
+		List<Session> sessions = sessionRepository.findAllWithSpeakerAndTag();
+
+		return sessions.stream()
+			.map(session -> SessionListResponseDto.from(
+				session,
+				SpeakerResponseDto.from(session.getSpeaker()),
+				TagResponseDto.from(session.getTag())
+			))
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -13,7 +13,11 @@ import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.entity.Tag;
+import eightplusone.bit.fit.domain.tag.repository.TagRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
@@ -25,6 +29,8 @@ public class SessionService {
 	private final SessionRepository sessionRepository;
 	private final String SESSION_CONGESTION_KEY = "session_congestion";
 	private final String SESSION_USER_KEY = "session_user";
+	private final TagRepository tagRepository;
+	private final SpeakerRepository speakerRepository;
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
@@ -98,14 +104,19 @@ public class SessionService {
 	}
 
 	public List<SessionListResponseDto> getSessionsList() {
-		List<Session> sessions = sessionRepository.findAllWithSpeakerAndTag();
+		List<Session> sessions = sessionRepository.findAll();
 
 		return sessions.stream()
-			.map(session -> SessionListResponseDto.from(
-				session,
-				SpeakerResponseDto.from(session.getSpeaker()),
-				TagResponseDto.from(session.getTag())
-			))
+			.map(session -> {
+				Speaker speaker = speakerRepository.findBySession_SessionId(session.getSessionId());
+				Tag tag = tagRepository.findBySession_SessionId(session.getSessionId());
+
+				return SessionListResponseDto.from(
+					session,
+					SpeakerResponseDto.from(speaker),
+					TagResponseDto.from(tag)
+				);
+			})
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -103,20 +105,18 @@ public class SessionService {
 		}
 	}
 
-	public List<SessionListResponseDto> getSessionsList() {
-		List<Session> sessions = sessionRepository.findAll();
+	public Page<SessionListResponseDto> getSessionsList(Pageable pageable) {
+		Page<Session> sessions = sessionRepository.findAll(pageable);
 
-		return sessions.stream()
-			.map(session -> {
-				Speaker speaker = speakerRepository.findBySession_SessionId(session.getSessionId());
-				Tag tag = tagRepository.findBySession_SessionId(session.getSessionId());
+		return sessions.map(session -> {
+			Speaker speaker = speakerRepository.findBySession_SessionId(session.getSessionId());
+			Tag tag = tagRepository.findBySession_SessionId(session.getSessionId());
 
-				return SessionListResponseDto.from(
-					session,
-					SpeakerResponseDto.from(speaker),
-					TagResponseDto.from(tag)
-				);
-			})
-			.collect(Collectors.toList());
+			return SessionListResponseDto.from(
+				session,
+				SpeakerResponseDto.from(speaker),
+				TagResponseDto.from(tag)
+			);
+		});
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -105,17 +105,14 @@ public class SessionService {
 		}
 	}
 
-	public Page<SessionListResponseDto> getSessionsList(Pageable pageable) {
-		Page<Session> sessions = sessionRepository.findAll(pageable);
+	public Page<SessionListResponseDto> getSessionsList(Pageable pageable, TagResponseDto tagDto) {
+		Page<Object[]> sessions = tagRepository.tagFilterAndSearch(pageable, tagDto);
 
 		return sessions.map(session -> {
-			Speaker speaker = speakerRepository.findBySession_SessionId(session.getSessionId());
-			Tag tag = tagRepository.findBySession_SessionId(session.getSessionId());
-
 			return SessionListResponseDto.from(
-				session,
-				SpeakerResponseDto.from(speaker),
-				TagResponseDto.from(tag)
+				(Session)session[0],
+				SpeakerResponseDto.from((Speaker)session[2]),
+				TagResponseDto.from((Tag)session[1])
 			);
 		});
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/dto/SpeakerResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/dto/SpeakerResponseDto.java
@@ -1,11 +1,13 @@
 package eightplusone.bit.fit.domain.speaker.dto;
 
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(name = "SpeakerResponseDto: 연사 정보 응답 dto")
 public class SpeakerResponseDto {
 	private String image;
 

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/dto/SpeakerResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/dto/SpeakerResponseDto.java
@@ -1,0 +1,20 @@
+package eightplusone.bit.fit.domain.speaker.dto;
+
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SpeakerResponseDto {
+	private String image;
+
+	private String name;
+
+	public static SpeakerResponseDto from(Speaker speaker) {
+		return SpeakerResponseDto.builder()
+			.image(speaker.getImage())
+			.name(speaker.getName())
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
@@ -3,6 +3,7 @@ package eightplusone.bit.fit.domain.speaker.entity;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +32,7 @@ public class Speaker {
 	@Column(nullable = false, length = 200)
 	private String description;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -35,4 +36,12 @@ public class Speaker {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
+
+	@Builder
+	public Speaker(String image, String name, String description, Session session) {
+		this.image = image;
+		this.name = name;
+		this.description = description;
+		this.session = session;
+	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/entity/Speaker.java
@@ -1,0 +1,37 @@
+package eightplusone.bit.fit.domain.speaker.entity;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "speakers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Speaker {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long speakerId;
+
+	@Column(nullable = false, length = 200)
+	private String image;
+
+	@Column(nullable = false, length = 20)
+	private String name;
+
+	@Column(nullable = false, length = 200)
+	private String description;
+
+	@OneToOne
+	@JoinColumn(name = "session_id", nullable = false)
+	private Session session;
+}

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
@@ -1,0 +1,8 @@
+package eightplusone.bit.fit.domain.speaker.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+
+public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
+}

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 
 public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
+	Speaker findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/service/SpeakerService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/service/SpeakerService.java
@@ -1,0 +1,7 @@
+package eightplusone.bit.fit.domain.speaker.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SpeakerService {
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagResponseDto.java
@@ -1,0 +1,26 @@
+package eightplusone.bit.fit.domain.tag.dto;
+
+import eightplusone.bit.fit.domain.tag.entity.Tag;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class TagResponseDto {
+	private String field;
+
+	private String topic;
+
+	private String type;
+
+	private String level;
+
+	public static TagResponseDto from(Tag tag) {
+		return TagResponseDto.builder()
+			.field(tag.getField())
+			.topic(tag.getTopic())
+			.type(tag.getType())
+			.level(tag.getLevel())
+			.build();
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagResponseDto.java
@@ -1,11 +1,13 @@
 package eightplusone.bit.fit.domain.tag.dto;
 
 import eightplusone.bit.fit.domain.tag.entity.Tag;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(name = "TagResponseDto: 태그 정보 응답 dto")
 public class TagResponseDto {
 	private String field;
 

--- a/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
@@ -1,0 +1,40 @@
+package eightplusone.bit.fit.domain.tag.entity;
+
+import eightplusone.bit.fit.domain.session.entity.Session;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "tags")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long tagId;
+
+	@Column(nullable = false, length = 20)
+	private String field;
+
+	@Column(nullable = false, length = 20)
+	private String topic;
+
+	@Column(nullable = false, length = 20)
+	private String type;
+
+	@Column(nullable = false, length = 5)
+	private String level;
+
+	@OneToOne
+	@JoinColumn(name = "session_id", nullable = false)
+	private Session session;
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
@@ -11,6 +11,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,4 +39,13 @@ public class Tag {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
+
+	@Builder
+	public Tag(String field, String topic, String type, String level, Session session) {
+		this.field = field;
+		this.topic = topic;
+		this.type = type;
+		this.level = level;
+		this.session = session;
+	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/entity/Tag.java
@@ -3,6 +3,7 @@ package eightplusone.bit.fit.domain.tag.entity;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -34,7 +35,7 @@ public class Tag {
 	@Column(nullable = false, length = 5)
 	private String level;
 
-	@OneToOne
+	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "session_id", nullable = false)
 	private Session session;
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 
-public interface TagRepository extends JpaRepository<Tag, Long> {
+public interface TagRepository extends JpaRepository<Tag, Long>, TagRepositoryCustom {
 	Tag findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+	Tag findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
@@ -1,0 +1,8 @@
+package eightplusone.bit.fit.domain.tag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import eightplusone.bit.fit.domain.tag.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepositoryCustom.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepositoryCustom.java
@@ -1,0 +1,10 @@
+package eightplusone.bit.fit.domain.tag.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+
+public interface TagRepositoryCustom {
+	Page<Object[]> tagFilterAndSearch(Pageable pageable, TagResponseDto dto);
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepositoryImpl.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepositoryImpl.java
@@ -1,0 +1,80 @@
+package eightplusone.bit.fit.domain.tag.repository;
+
+import static eightplusone.bit.fit.domain.session.entity.QSession.*;
+import static eightplusone.bit.fit.domain.speaker.entity.QSpeaker.*;
+import static eightplusone.bit.fit.domain.tag.entity.QTag.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class TagRepositoryImpl implements TagRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Page<Object[]> tagFilterAndSearch(Pageable pageable, TagResponseDto dto) {
+		List<Tuple> results = queryFactory
+			.select(session, tag, speaker)
+			.from(session)
+			.leftJoin(tag).on(tag.session.eq(session))
+			// .leftJoin(tag).on(session.sessionId.eq(tag.session.sessionId))
+			.leftJoin(speaker).on(speaker.session.eq(session))
+			.where(
+				containField(dto.getField()),
+				containTopic(dto.getTopic()),
+				containType(dto.getType()),
+				containLevel(dto.getLevel())
+			)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
+
+		List<Object[]> mappedResults = results.stream()
+			.map(Tuple::toArray)
+			.toList();
+
+		JPAQuery<Long> countQuery = queryFactory
+			.select(session.count())
+			.from(session)
+			.leftJoin(tag).on(tag.session.eq(session))
+			.where(
+				containField(dto.getField()),
+				containTopic(dto.getTopic()),
+				containType(dto.getType()),
+				containLevel(dto.getLevel())
+			);
+
+		return new PageImpl<>(mappedResults, pageable, countQuery.fetchOne());
+	}
+
+	public static BooleanExpression containField(String field) {
+		return StringUtils.hasText(field) ? tag.field.eq(field) : null;
+	}
+
+	public static BooleanExpression containTopic(String topic) {
+		return StringUtils.hasText(topic) ? tag.topic.eq(topic) : null;
+	}
+
+	public static BooleanExpression containType(String type) {
+		return StringUtils.hasText(type) ? tag.type.eq(type) : null;
+	}
+
+	public static BooleanExpression containLevel(String level) {
+		return StringUtils.hasText(level) ? tag.level.eq(level) : null;
+	}
+}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/service/TagService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/service/TagService.java
@@ -1,0 +1,7 @@
+package eightplusone.bit.fit.domain.tag.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TagService {
+}

--- a/src/main/java/eightplusone/bit/fit/global/config/QueryDslConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/QueryDslConfig.java
@@ -1,0 +1,22 @@
+package eightplusone.bit.fit.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}
+

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -1,7 +1,8 @@
 package eightplusone.bit.fit.global.enums;
 
-import lombok.Getter;
 import org.springframework.http.HttpMethod;
+
+import lombok.Getter;
 
 @Getter
 public enum ApiEndpoint {
@@ -13,6 +14,7 @@ public enum ApiEndpoint {
 		"/call",
 		"/ws",
 		"/ws/**",
+		"/api/v1/session/all"
 	}),
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -1,23 +1,38 @@
 package eightplusone.bit.fit.domain.session.service;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.util.ReflectionTestUtils.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.entity.Tag;
+import eightplusone.bit.fit.domain.tag.repository.TagRepository;
+import eightplusone.bit.fit.support.fixture.SessionFixture;
+import eightplusone.bit.fit.support.fixture.SpeakerFixture;
+import eightplusone.bit.fit.support.fixture.TagFixture;
 
 class SessionServiceTest {
 
@@ -32,6 +47,9 @@ class SessionServiceTest {
 
 	@InjectMocks
 	private SessionService sessionService;
+
+	@Mock
+	private TagRepository tagRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -109,5 +127,129 @@ class SessionServiceTest {
 				msg.get("percent").equals(percent) &&
 				msg.get("level").equals(newLevel);
 		}));
+	}
+
+	@Test
+	@DisplayName("태그를 기반으로 세션 목록을 조회한다")
+	void getSessionsList() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		Session session1 = SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession();
+		Session session4 = SessionFixture.SESSION_STAGE_2_FIXTURE_1.createSession();
+
+		Speaker speaker1 = SpeakerFixture.SPEAKER_FIXTURE_1.createSpeaker();
+		Speaker speaker4 = SpeakerFixture.SPEAKER_FIXTURE_4.createSpeaker();
+
+		Tag tag1 = TagFixture.TAG_FIXTURE_1.createTag();
+
+		TagResponseDto tagDto = TagResponseDto.from(tag1);
+
+		List<Object[]> mockData = new ArrayList<>();
+		mockData.add(new Object[] {session1, tag1, speaker1});
+		mockData.add(new Object[] {session4, tag1, speaker4});
+
+		List<Object[]> filteredData = mockData.stream()
+			.filter(data -> ((Tag)data[1]).getField().equals(tagDto.getField()))
+			.toList();
+
+		long count = filteredData.size();
+
+		when(tagRepository.tagFilterAndSearch(pageable, tagDto))
+			.thenReturn(new PageImpl<>(filteredData, pageable, count));
+
+		// when
+		Page<SessionListResponseDto> result = sessionService.getSessionsList(pageable, tagDto);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(2);
+
+		List<SessionListResponseDto> content = result.getContent();
+
+		assertAll(
+			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
+			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
+
+			() -> assertThat(content.get(1).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker4.getName()),
+			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag1.getField())
+		);
+	}
+
+	@Test
+	@DisplayName("세션 목록을 전체 조회한다")
+	void getAllSessionsList() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		Session session1 = SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession();
+		Session session2 = SessionFixture.SESSION_STAGE_1_FIXTURE_2.createSession();
+		Session session3 = SessionFixture.SESSION_STAGE_1_FIXTURE_3.createSession();
+		Session session4 = SessionFixture.SESSION_STAGE_2_FIXTURE_1.createSession();
+		Session session5 = SessionFixture.SESSION_STAGE_2_FIXTURE_2.createSession();
+		Session session6 = SessionFixture.SESSION_STAGE_2_FIXTURE_3.createSession();
+
+		Speaker speaker1 = SpeakerFixture.SPEAKER_FIXTURE_1.createSpeaker();
+		Speaker speaker2 = SpeakerFixture.SPEAKER_FIXTURE_2.createSpeaker();
+		Speaker speaker3 = SpeakerFixture.SPEAKER_FIXTURE_3.createSpeaker();
+		Speaker speaker4 = SpeakerFixture.SPEAKER_FIXTURE_4.createSpeaker();
+		Speaker speaker5 = SpeakerFixture.SPEAKER_FIXTURE_5.createSpeaker();
+		Speaker speaker6 = SpeakerFixture.SPEAKER_FIXTURE_6.createSpeaker();
+
+		Tag tag1 = TagFixture.TAG_FIXTURE_1.createTag();
+		Tag tag2 = TagFixture.TAG_FIXTURE_2.createTag();
+		Tag tag3 = TagFixture.TAG_FIXTURE_3.createTag();
+		Tag tag4 = TagFixture.TAG_FIXTURE_4.createTag();
+		Tag tag5 = TagFixture.TAG_FIXTURE_5.createTag();
+		Tag tag6 = TagFixture.TAG_FIXTURE_6.createTag();
+
+		List<Object[]> mockData = new ArrayList<>();
+		mockData.add(new Object[] {session1, tag1, speaker1});
+		mockData.add(new Object[] {session2, tag2, speaker2});
+		mockData.add(new Object[] {session3, tag3, speaker3});
+		mockData.add(new Object[] {session4, tag4, speaker4});
+		mockData.add(new Object[] {session5, tag5, speaker5});
+		mockData.add(new Object[] {session6, tag6, speaker6});
+
+		Page<Object[]> mockPage = new PageImpl<>(mockData, pageable, mockData.size());
+
+		when(tagRepository.tagFilterAndSearch(pageable, null)).thenReturn(mockPage);
+
+		// when
+		Page<SessionListResponseDto> result = sessionService.getSessionsList(pageable, null);
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).hasSize(6);
+
+		List<SessionListResponseDto> content = result.getContent();
+
+		assertAll(
+			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
+			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
+
+			() -> assertThat(content.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
+			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag2.getField()),
+
+			() -> assertThat(content.get(2).getTitle()).isEqualTo(session3.getTitle()),
+			() -> assertThat(content.get(2).getSpeaker().getName()).isEqualTo(speaker3.getName()),
+			() -> assertThat(content.get(2).getTags().getField()).isEqualTo(tag3.getField()),
+
+			() -> assertThat(content.get(3).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(3).getSpeaker().getName()).isEqualTo(speaker4.getName()),
+			() -> assertThat(content.get(3).getTags().getField()).isEqualTo(tag4.getField()),
+
+			() -> assertThat(content.get(4).getTitle()).isEqualTo(session5.getTitle()),
+			() -> assertThat(content.get(4).getSpeaker().getName()).isEqualTo(speaker5.getName()),
+			() -> assertThat(content.get(4).getTags().getField()).isEqualTo(tag5.getField()),
+
+			() -> assertThat(content.get(5).getTitle()).isEqualTo(session6.getTitle()),
+			() -> assertThat(content.get(5).getSpeaker().getName()).isEqualTo(speaker6.getName()),
+			() -> assertThat(content.get(5).getTags().getField()).isEqualTo(tag6.getField())
+		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -58,6 +58,7 @@ class SessionServiceTest {
 	}
 
 	@Test
+	@DisplayName("체크인을 한다.")
 	void checkIn() {
 		// Given
 		String email = "test@gmail.com";
@@ -70,6 +71,7 @@ class SessionServiceTest {
 	}
 
 	@Test
+	@DisplayName("체크아웃을 한다.")
 	void checkOut() {
 		// Given
 		String email = "test@gmail.com";
@@ -82,6 +84,7 @@ class SessionServiceTest {
 	}
 
 	@Test
+	@DisplayName("세션혼잡도를 전송한다.")
 	void getUpdatedSessionData() {
 		Session session = new Session();
 		setField(session, "audioChannel", 123);
@@ -101,6 +104,7 @@ class SessionServiceTest {
 	}
 
 	@Test
+	@DisplayName("혼잡도가 크게 바뀔 경우 전송한다.")
 	void updateAndBroadcastIfChanged() {
 		// Given
 		Integer audioChannel = 123;

--- a/src/test/java/eightplusone/bit/fit/support/fixture/SpeakerFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/SpeakerFixture.java
@@ -1,0 +1,35 @@
+package eightplusone.bit.fit.support.fixture;
+
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import lombok.Getter;
+
+@Getter
+public enum SpeakerFixture {
+	SPEAKER_FIXTURE_1("http://image1.com", "스피커1", "인공지능 전문가입니다.", SessionFixture.SESSION_STAGE_1_FIXTURE_1),
+	SPEAKER_FIXTURE_2("http://image2.com", "스피커2", "뭐이런분야 전문가입니다.", SessionFixture.SESSION_STAGE_1_FIXTURE_2),
+	SPEAKER_FIXTURE_6("http://image6.com", "스피커6", "굳굳굳 전문가입니다.", SessionFixture.SESSION_STAGE_1_FIXTURE_3),
+	SPEAKER_FIXTURE_3("http://image3.com", "스피커3", "이야 멋진 전문가입니다.", SessionFixture.SESSION_STAGE_2_FIXTURE_1),
+	SPEAKER_FIXTURE_4("http://image4.com", "스피커4", "백엔드 전문가입니다.", SessionFixture.SESSION_STAGE_2_FIXTURE_2),
+	SPEAKER_FIXTURE_5("http://image5.com", "스피커5", "프론트엔드 전문가입니다.", SessionFixture.SESSION_STAGE_2_FIXTURE_3);
+
+	private final String image;
+	private final String name;
+	private final String description;
+	private final SessionFixture session;
+
+	SpeakerFixture(String image, String name, String description, SessionFixture session) {
+		this.image = image;
+		this.name = name;
+		this.description = description;
+		this.session = session;
+	}
+
+	public Speaker createSpeaker() {
+		return Speaker.builder()
+			.image(image)
+			.name(name)
+			.description(description)
+			.session(session.createSession())
+			.build();
+	}
+}

--- a/src/test/java/eightplusone/bit/fit/support/fixture/TagFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/TagFixture.java
@@ -1,0 +1,38 @@
+package eightplusone.bit.fit.support.fixture;
+
+import eightplusone.bit.fit.domain.tag.entity.Tag;
+import lombok.Getter;
+
+@Getter
+public enum TagFixture {
+	TAG_FIXTURE_1("AI", "머신러닝", "타입1", "초급", SessionFixture.SESSION_STAGE_1_FIXTURE_1),
+	TAG_FIXTURE_2("백엔드", "보안", "타입2", "중급", SessionFixture.SESSION_STAGE_1_FIXTURE_2),
+	TAG_FIXTURE_3("프론트엔드", "머신러닝", "타입3", "고급", SessionFixture.SESSION_STAGE_1_FIXTURE_3),
+	TAG_FIXTURE_4("AI", "머신러닝", "타입1", "초급", SessionFixture.SESSION_STAGE_2_FIXTURE_1),
+	TAG_FIXTURE_5("백엔드", "보안", "타입2", "고급", SessionFixture.SESSION_STAGE_2_FIXTURE_2),
+	TAG_FIXTURE_6("프론트엔드", "머신러닝", "타입3", "초급", SessionFixture.SESSION_STAGE_2_FIXTURE_3);
+
+	private final String field;
+	private final String topic;
+	private final String type;
+	private final String level;
+	private final SessionFixture session;
+
+	TagFixture(String field, String topic, String type, String level, SessionFixture session) {
+		this.field = field;
+		this.topic = topic;
+		this.type = type;
+		this.level = level;
+		this.session = session;
+	}
+
+	public Tag createTag() {
+		return Tag.builder()
+			.field(field)
+			.topic(topic)
+			.type(type)
+			.level(level)
+			.session(session.createSession())
+			.build();
+	}
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [X] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed. #41

### 변경 사항
1. QueryDsl을 통한 필터링 및 페이징처리
세션, 태그, 연사 정보는 조회시 조인이 필요하고, 필터링을 해야한다는 점을 감안하여 QueryDsl을 사용했습니다.
필터가 없을 경우에는 전체 조회를, 있을 경우엔 필터링이 되도록 구현하였습니다.
- 관련 의존성 추가하였습니다.

### 테스트 결과
- 필터가 없을 경우 전체 조회
<img width="945" alt="스크린샷 2025-03-19 오후 2 02 58" src="https://github.com/user-attachments/assets/0c7a343d-799d-47df-8fce-3082a277a51b" />

</br>
</br>

- 필터에 맞는 것이 없을 경우 빈 리스트 반환
<img width="937" alt="스크린샷 2025-03-19 오후 2 03 33" src="https://github.com/user-attachments/assets/1536883a-9e88-4e67-b750-af93de23196e" />

</br>
</br>

- 필터에 맞는 세션 반환
<img width="938" alt="스크린샷 2025-03-19 오후 2 03 23" src="https://github.com/user-attachments/assets/e5f2e5dd-25d4-40df-8756-8f585a092c39" />

</br>
</br>

- 테스트 코드
<img width="345" alt="스크린샷 2025-03-19 오후 2 57 22" src="https://github.com/user-attachments/assets/78259cd1-f50f-46cf-8153-954a0edcb51f" />
