### PR TITLE
[#53] TTL 수정

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -39,7 +39,7 @@ public class ChatController {
 		@Payload ChatMessageDto message,
 		@Parameter(description = "사용자 ID", example = "user123") @Header("User-Id") String userId
 	) throws JsonProcessingException {
-		chatService.sendMessage(message, userId, sessionId);
+		chatService.sendMessage(message, userId, Long.valueOf(sessionId));
 	}
 
 	@Operation(summary = "최근 메시지 조회", description = "특정 채팅방의 최근 메시지를 조회합니다.")
@@ -86,6 +86,6 @@ public class ChatController {
 	public List<ChatMessageDto> getSortedQuestions(
 		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable String sessionId
 	) {
-		return chatService.getSortedQuestionMessages(sessionId);
+		return chatService.getSortedQuestionMessages(Long.valueOf(sessionId));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
@@ -15,6 +15,7 @@ public class ChatMessageDto {
 	private String name;
 	private String userId;
 	private String sessionId;
+	private String timestamp;
 
 	@JsonCreator
 	public ChatMessageDto(
@@ -23,12 +24,14 @@ public class ChatMessageDto {
 		@JsonProperty("message") String message,
 		@JsonProperty("name") String name,
 		@JsonProperty("userId") String userId,
-		@JsonProperty("sessionId") String sessionId) {
+		@JsonProperty("sessionId") String sessionId,
+		@JsonProperty("timestamp") String timestamp) {
 		this.messageId = messageId;
 		this.category = category;
 		this.message = message;
 		this.name = name;
 		this.userId = userId;
 		this.sessionId = sessionId;
+		this.timestamp = timestamp;
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
@@ -14,6 +14,7 @@ public class ChatMessageDto {
 	private String message;
 	private String name;
 	private String userId;
+	private String sessionId;
 
 	@JsonCreator
 	public ChatMessageDto(
@@ -21,11 +22,13 @@ public class ChatMessageDto {
 		@JsonProperty("category") ChatCategory category,
 		@JsonProperty("message") String message,
 		@JsonProperty("name") String name,
-		@JsonProperty("userId") String userId) {
+		@JsonProperty("userId") String userId,
+		@JsonProperty("sessionId") String sessionId) {
 		this.messageId = messageId;
 		this.category = category;
 		this.message = message;
 		this.name = name;
 		this.userId = userId;
+		this.sessionId = sessionId;
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
@@ -14,7 +14,7 @@ public class ChatMessageDto {
 	private String message;
 	private String name;
 	private String userId;
-	private String sessionId;
+	private Long sessionId;
 	private String timestamp;
 
 	@JsonCreator
@@ -24,7 +24,7 @@ public class ChatMessageDto {
 		@JsonProperty("message") String message,
 		@JsonProperty("name") String name,
 		@JsonProperty("userId") String userId,
-		@JsonProperty("sessionId") String sessionId,
+		@JsonProperty("sessionId") Long sessionId,
 		@JsonProperty("timestamp") String timestamp) {
 		this.messageId = messageId;
 		this.category = category;

--- a/src/main/java/eightplusone/bit/fit/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/entity/ChatMessage.java
@@ -19,7 +19,7 @@ public class ChatMessage {
 	@Id
 	private String messageId; // 메시지 PK
 
-	private String sessionId; // 강연 ID
+	private Long sessionId; // 강연 ID
 
 	private String userId; // 사용자 ID
 
@@ -33,7 +33,7 @@ public class ChatMessage {
 
 	// 기존 메시지를 새로 저장할 때 사용하는 생성자
 	@Builder
-	public ChatMessage(String sessionId, String userId, ChatCategory category, String message) {
+	public ChatMessage(Long sessionId, String userId, ChatCategory category, String message) {
 		this.messageId = UUID.randomUUID().toString();
 		this.sessionId = sessionId;
 		this.userId = userId;
@@ -43,7 +43,7 @@ public class ChatMessage {
 	}
 
 	// Redis에서 가져온 기존 메시지를 복원할 때 사용하는 생성자
-	public ChatMessage(String messageId, String sessionId, String userId, ChatCategory category, String message,
+	public ChatMessage(String messageId, Long sessionId, String userId, ChatCategory category, String message,
 		String timestamp) {
 		this.messageId = messageId;  // 기존 메시지 ID 유지
 		this.sessionId = sessionId;

--- a/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
@@ -1,6 +1,8 @@
 package eightplusone.bit.fit.domain.chat.repository;
 
 import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import java.time.Duration;
 import java.util.List;
 import org.slf4j.Logger;
@@ -12,13 +14,14 @@ import org.springframework.stereotype.Repository;
 public class ChatRepository {
 	private static final Logger log = LoggerFactory.getLogger(ChatRepository.class);
 	private static final String CHAT_LIST_KEY = "chat-";
-	private static final String LIKES_KEY = "chat_like";
 	private static final int MAX_CHAT_SIZE = 1000;
 
 	private final RedisTemplate<String, Object> redisTemplate;
+	private final SessionRepository sessionRepository;
 
-	public ChatRepository(RedisTemplate<String, Object> redisTemplate) {
+	public ChatRepository(RedisTemplate<String, Object> redisTemplate, SessionRepository sessionRepository) {
 		this.redisTemplate = redisTemplate;
+		this.sessionRepository = sessionRepository;
 	}
 
 	// 채팅 메시지 저장
@@ -26,14 +29,18 @@ public class ChatRepository {
 		String chatKey = CHAT_LIST_KEY + message.getSessionId();
 
 		redisTemplate.opsForList().rightPush(chatKey, message);
-		// redisTemplate.expire(chatKey, Duration.ofHours(2)); // 2시간 후 만료
+		Session session = sessionRepository.findById(message.getSessionId()).orElse(null);
+		if (session != null) {
+			long ttlInSeconds = session.getLectureDuration() + Duration.ofMinutes(30).getSeconds();
 
-		// TTL이 설정되었는지 확인하기 위해 직접 로그 출력
-		Boolean expireResult = redisTemplate.expire(chatKey, Duration.ofHours(2));
-		log.info("🔍 TTL 적용 결과 (true: 성공, false: 실패): {}", expireResult);
+			Boolean expireResult = redisTemplate.expire(chatKey, Duration.ofSeconds(ttlInSeconds));
+			log.info("🔍 TTL 적용 결과 (true: 성공, false: 실패): {}", expireResult);
 
-		Long ttl = redisTemplate.getExpire(chatKey);
-		log.info("🔍 현재 TTL 값 (초 단위): {}", ttl);
+			Long ttl = redisTemplate.getExpire(chatKey);
+			log.info("🔍 현재 TTL 값 (초 단위): {}", ttl);
+		} else {
+			log.warn("🚨 세션 정보를 찾을 수 없어 TTL을 설정하지 못했습니다. sessionId: {}", message.getSessionId());
+		}
 
 		// 리스트 크기를 1000개로 유지하도록 `trim()` 적용
 		redisTemplate.opsForList().trim(chatKey, -MAX_CHAT_SIZE, -1);
@@ -44,7 +51,7 @@ public class ChatRepository {
 		String chatKey = CHAT_LIST_KEY + sessionId;
 		List<Object> messages = redisTemplate.opsForList().range(chatKey, 0, -1);
 
-		// 💡 Redis에서 가져온 데이터 확인 로그 추가
+		// Redis 에서 가져온 데이터 확인 로그 추가
 		log.info("🔍 Redis에서 가져온 메시지 ({}): {}", chatKey, messages);
 
 		return messages;

--- a/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
@@ -28,10 +28,8 @@ public class ChatRepository {
 		redisTemplate.opsForList().rightPush(chatKey, message);
 		redisTemplate.expire(chatKey, Duration.ofHours(2)); // 2시간 후 만료
 
-		// 특정 채팅방의 메시지를 1000개만 유지
-		if (redisTemplate.opsForList().size(chatKey) > MAX_CHAT_SIZE) {
-			redisTemplate.opsForList().leftPop(chatKey);
-		}
+		// 리스트 크기를 1000개로 유지하도록 `trim()` 적용
+		redisTemplate.opsForList().trim(chatKey, -MAX_CHAT_SIZE, -1);
 	}
 
 	// 특정 채팅방(sessionId)의 최근 메시지 조회

--- a/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
@@ -26,7 +26,14 @@ public class ChatRepository {
 		String chatKey = CHAT_LIST_KEY + message.getSessionId();
 
 		redisTemplate.opsForList().rightPush(chatKey, message);
-		redisTemplate.expire(chatKey, Duration.ofHours(2)); // 2시간 후 만료
+		// redisTemplate.expire(chatKey, Duration.ofHours(2)); // 2시간 후 만료
+
+		// TTL이 설정되었는지 확인하기 위해 직접 로그 출력
+		Boolean expireResult = redisTemplate.expire(chatKey, Duration.ofHours(2));
+		log.info("🔍 TTL 적용 결과 (true: 성공, false: 실패): {}", expireResult);
+
+		Long ttl = redisTemplate.getExpire(chatKey);
+		log.info("🔍 현재 TTL 값 (초 단위): {}", ttl);
 
 		// 리스트 크기를 1000개로 유지하도록 `trim()` 적용
 		redisTemplate.opsForList().trim(chatKey, -MAX_CHAT_SIZE, -1);

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -11,7 +11,6 @@ import eightplusone.bit.fit.domain.user.repository.UserRedisRepository;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.global.exception.CustomException;
 import eightplusone.bit.fit.global.exception.ErrorCode;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -123,7 +122,7 @@ public class ChatService {
 			.map(obj -> {
 				if (obj instanceof ChatMessageDto dto) {
 					return new ChatMessage(dto.getMessageId(), sessionId, dto.getUserId(), dto.getCategory(),
-						dto.getMessage(), LocalDateTime.now().toString());
+						dto.getMessage(), dto.getTimestamp());
 				} else if (obj instanceof ChatMessage message) {
 					return message;  // 기존 ChatMessage 객체 그대로 사용
 				}
@@ -164,9 +163,10 @@ public class ChatService {
 					msg.getMessageId(),
 					msg.getCategory(),
 					msg.getMessage(),
-					userName != null ? userName : "알 수 없음", // ✅ `null`이면 기본값 설정
+					userName != null ? userName : "알 수 없음", // `null`이면 기본값 설정
 					msg.getUserId(), // `userId`가 `null`이 아닌지 확인
-					msg.getSessionId()
+					msg.getSessionId(),
+					msg.getTimestamp()
 				);
 			})
 			.collect(Collectors.toList());

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -165,7 +165,8 @@ public class ChatService {
 					msg.getCategory(),
 					msg.getMessage(),
 					userName != null ? userName : "알 수 없음", // ✅ `null`이면 기본값 설정
-					msg.getUserId() // `userId`가 `null`이 아닌지 확인
+					msg.getUserId(), // `userId`가 `null`이 아닌지 확인
+					msg.getSessionId()
 				);
 			})
 			.collect(Collectors.toList());

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -35,7 +35,7 @@ public class ChatService {
 	}
 
 	// 메시지 전송 (Redis Pub/Sub 사용)
-	public void sendMessage(ChatMessageDto dto, String userId, String sessionId) throws JsonProcessingException {
+	public void sendMessage(ChatMessageDto dto, String userId, Long sessionId) throws JsonProcessingException {
 		if (dto.getMessage() == null || dto.getMessage().trim().isEmpty()) {
 			throw new CustomException(ErrorCode.INVALID_MESSAGE_FORMAT);
 		}
@@ -44,7 +44,7 @@ public class ChatService {
 			throw new CustomException(ErrorCode.MESSAGE_TOO_LONG);
 		}
 
-		if (!chatRepository.existsBySessionId(sessionId)) {
+		if (!chatRepository.existsBySessionId(String.valueOf(sessionId))) {
 			throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
 		}
 
@@ -109,12 +109,12 @@ public class ChatService {
 	}
 
 	// 특정 세션의 QUESTION 메시지를 좋아요 기준으로 정렬
-	public List<ChatMessageDto> getSortedQuestionMessages(String sessionId) {
-		if (!chatRepository.existsBySessionId(sessionId)) {
+	public List<ChatMessageDto> getSortedQuestionMessages(Long sessionId) {
+		if (!chatRepository.existsBySessionId(String.valueOf(sessionId))) {
 			throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
 		}
 
-		List<Object> rawMessages = chatRepository.getRecentMessages(sessionId);
+		List<Object> rawMessages = chatRepository.getRecentMessages(String.valueOf(sessionId));
 		log.info("🔍 Redis에서 가져온 원본 메시지: {}", rawMessages);
 
 		// ChatMessageDto -> ChatMessage 변환 (userId 추가)

--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -1,9 +1,5 @@
 package eightplusone.bit.fit.domain.session.entity;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -13,6 +9,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -47,6 +47,9 @@ public class Session {
 	@Column(nullable = false)
 	private Integer audioChannel;
 
+	@Column(nullable = false)
+	private Long lectureDuration; // 강연 시간 (초 단위)
+
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MySession> mySessions = new ArrayList<>();
 
@@ -60,5 +63,13 @@ public class Session {
 		this.endTime = endTime;
 		this.standardCount = standardCount;
 		this.audioChannel = audioChannel;
+		this.lectureDuration = Duration.between(startTime, endTime).getSeconds(); // 강연 시간 저장
+	}
+
+	// 강연 시간이 변경될 경우 업데이트
+	public void updateSessionTime(LocalDateTime startTime, LocalDateTime endTime) {
+		this.startTime = startTime;
+		this.endTime = endTime;
+		this.lectureDuration = Duration.between(startTime, endTime).getSeconds();
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -3,11 +3,15 @@ package eightplusone.bit.fit.domain.chat.repository;
 import static org.junit.jupiter.api.Assertions.*;
 
 import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
+import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -27,14 +31,38 @@ public class ChatRepositoryTest {
 	@Autowired
 	private RedisTemplate<String, Object> redisTemplate;
 
-	private static final String SESSION_ID = "testSession";
+	@Autowired
+	private SessionRepository sessionRepository;
+
+	private static final Long SESSION_ID = 1L;
 
 	@BeforeEach
 	void setUp() {
-		// 테스트 전에 Redis에서 기존 데이터 삭제
-		chatRepository.clearChat(SESSION_ID);
+		// 기존 데이터 삭제
+		chatRepository.clearChat(SESSION_ID.toString());
+		sessionRepository.deleteAll(); // 기존 세션 데이터 정리
+
+		// 테스트용 세션 미리 저장 (강연시간: 1시간)
+		Session testSession = Session.builder()
+			.title("테스트 세션")
+			.sessionImage("test.jpg")
+			.summary("테스트용 강연")
+			.startTime(LocalDateTime.now())
+			.endTime(LocalDateTime.now().plusHours(1)) // 강연시간 1시간
+			.standardCount(100)
+			.audioChannel(2)
+			.build();
+		sessionRepository.save(testSession);
+
+		// 저장 후 검증
 		Long count = redisTemplate.opsForList().size("chat-" + SESSION_ID);
 		assertEquals(0, count, "clearChat() 이후에도 메시지가 남아 있음!");
+	}
+
+	@AfterEach
+	void tearDown() {
+		// 테스트 종료 후 세션 정리
+		sessionRepository.deleteAll();
 	}
 
 	@Test
@@ -50,7 +78,7 @@ public class ChatRepositoryTest {
 		}
 
 		// 저장된 메시지 개수 가져오기
-		List<Object> messages = chatRepository.getRecentMessages(SESSION_ID);
+		List<Object> messages = chatRepository.getRecentMessages(SESSION_ID.toString());
 
 		// 메시지가 1000개만 유지되는지 검증
 		assertEquals(1000, messages.size());
@@ -82,25 +110,32 @@ public class ChatRepositoryTest {
 
 	@Test
 	void testChatMessageExpiration() throws InterruptedException {
+		// 테스트용 세션 가져오기
+		Session session = sessionRepository.findById(SESSION_ID).orElse(null);
+		assertNotNull(session, "테스트용 세션이 존재해야 합니다!");
+
+		// 강연시간(1시간) + 30분 TTL 계산
+		long expectedTtl = session.getLectureDuration() + Duration.ofMinutes(30).getSeconds();
+
 		// 메시지 저장
 		ChatMessage message = ChatMessage.builder()
-			.sessionId(SESSION_ID)
+			.sessionId(session.getSessionId()) // 저장된 세션 ID 사용
 			.userId("user123")
 			.message("Test TTL")
 			.build();
 		chatRepository.saveMessage(message);
 
-		// TTL 설정 확인 (2시간 → 7200초)
-		Long ttl = redisTemplate.getExpire("chat-" + SESSION_ID);
+		// TTL 설정 확인
+		Long ttl = redisTemplate.getExpire("chat-" + session.getSessionId());
 		assertNotNull(ttl);
-		assertTrue(ttl > 7100); // 2시간(7200초) 설정되었는지 확인
+		assertTrue(ttl >= expectedTtl - 10, "TTL이 강연시간 + 30분과 일치하지 않음");
 
 		// TTL을 5초로 변경하여 삭제되는지 테스트
-		redisTemplate.expire("chat-" + SESSION_ID, Duration.ofSeconds(5));
+		redisTemplate.expire("chat-" + session.getSessionId(), Duration.ofSeconds(5));
 
 		// 6초 대기 후 데이터가 삭제되었는지 확인
 		Thread.sleep(6000);
-		assertFalse(chatRepository.existsBySessionId(SESSION_ID));
+		assertFalse(chatRepository.existsBySessionId(session.getSessionId().toString()));
 	}
 
 	// 특정 메시지가 삭제되었는지 직접 조회
@@ -116,13 +151,13 @@ public class ChatRepositoryTest {
 			chatRepository.saveMessage(message);
 		}
 
-		// ✅ Redis에 저장된 메시지 개수 직접 확인
+		// Redis에 저장된 메시지 개수 직접 확인
 		Long messageCount = redisTemplate.opsForList().size("chat-" + SESSION_ID);
 		System.out.println("🔍 Redis에 저장된 메시지 개수: " + messageCount);
 		assertNotNull(messageCount);
 		assertEquals(1000, messageCount, "Redis에 저장된 메시지 개수가 1000개가 아님!");
 
-		// ✅ Redis에서 가져온 메시지를 Set으로 변환하여 빠르게 비교
+		// Redis에서 가져온 메시지를 Set으로 변환하여 빠르게 비교
 		List<Object> messages = redisTemplate.opsForList().range("chat-" + SESSION_ID, 0, -1);
 		Set<String> messageSet = messages.stream()
 			.map(Object::toString)
@@ -131,12 +166,12 @@ public class ChatRepositoryTest {
 		System.out.println("🔍 현재 Redis에 저장된 메시지 리스트:");
 		messages.forEach(System.out::println);
 
-		// ✅ 첫 번째 100개 메시지("Message 1" ~ "Message 100")는 삭제되었어야 함
+		// 첫 번째 100개 메시지("Message 1" ~ "Message 100")는 삭제되었어야 함
 		IntStream.rangeClosed(1, 100).forEach(i -> {
 			assertFalse(messageSet.contains("Message " + i), "오래된 메시지가 삭제되지 않음: Message " + i);
 		});
 
-		// ✅ 가장 마지막 1000개는 유지되어야 함
+		// 가장 마지막 1000개는 유지되어야 함
 		IntStream.rangeClosed(101, 1100).forEach(i -> {
 			assertTrue(messageSet.contains("Message " + i), "최근 메시지가 유지되지 않음: Message " + i);
 		});

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -5,7 +5,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +33,8 @@ public class ChatRepositoryTest {
 	void setUp() {
 		// 테스트 전에 Redis에서 기존 데이터 삭제
 		chatRepository.clearChat(SESSION_ID);
+		Long count = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		assertEquals(0, count, "clearChat() 이후에도 메시지가 남아 있음!");
 	}
 
 	@Test
@@ -53,6 +59,27 @@ public class ChatRepositoryTest {
 		assertFalse(messages.contains("Message 1")); // 첫 번째 메시지가 삭제되었어야 함
 	}
 
+	// 메시지를 초과 저장할 때 삭제가 정상적으로 이루어지는지
+	@Test
+	void testMessageTrimmingInRedis() {
+		for (int i = 1; i <= 1200; i++) { // 1200개 저장
+			ChatMessage message = ChatMessage.builder()
+				.sessionId(SESSION_ID)
+				.userId("user" + i)
+				.message("Message " + i)
+				.build();
+			chatRepository.saveMessage(message);
+		}
+
+		// Redis에 저장된 메시지 개수 확인
+		Long messageCount = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		System.out.println("현재 Redis 저장된 메시지 개수: " + messageCount);
+
+		// Redis에 1000개만 남아 있는지 확인
+		assertNotNull(messageCount);
+		assertEquals(1000, messageCount);
+	}
+
 	@Test
 	void testChatMessageExpiration() throws InterruptedException {
 		// 메시지 저장
@@ -75,4 +102,44 @@ public class ChatRepositoryTest {
 		Thread.sleep(6000);
 		assertFalse(chatRepository.existsBySessionId(SESSION_ID));
 	}
+
+	// 특정 메시지가 삭제되었는지 직접 조회
+	@Disabled("Redis 메시지 삭제 로직이 확인되었으므로 테스트 비활성화")
+	@Test
+	void testOldestMessagesAreDeleted() {
+		for (int i = 1; i <= 1100; i++) { // 1100개 저장
+			ChatMessage message = ChatMessage.builder()
+				.sessionId(SESSION_ID)
+				.userId("user" + i)
+				.message("Message " + i)
+				.build();
+			chatRepository.saveMessage(message);
+		}
+
+		// ✅ Redis에 저장된 메시지 개수 직접 확인
+		Long messageCount = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		System.out.println("🔍 Redis에 저장된 메시지 개수: " + messageCount);
+		assertNotNull(messageCount);
+		assertEquals(1000, messageCount, "Redis에 저장된 메시지 개수가 1000개가 아님!");
+
+		// ✅ Redis에서 가져온 메시지를 Set으로 변환하여 빠르게 비교
+		List<Object> messages = redisTemplate.opsForList().range("chat-" + SESSION_ID, 0, -1);
+		Set<String> messageSet = messages.stream()
+			.map(Object::toString)
+			.collect(Collectors.toSet());
+
+		System.out.println("🔍 현재 Redis에 저장된 메시지 리스트:");
+		messages.forEach(System.out::println);
+
+		// ✅ 첫 번째 100개 메시지("Message 1" ~ "Message 100")는 삭제되었어야 함
+		IntStream.rangeClosed(1, 100).forEach(i -> {
+			assertFalse(messageSet.contains("Message " + i), "오래된 메시지가 삭제되지 않음: Message " + i);
+		});
+
+		// ✅ 가장 마지막 1000개는 유지되어야 함
+		IntStream.rangeClosed(101, 1100).forEach(i -> {
+			assertTrue(messageSet.contains("Message " + i), "최근 메시지가 유지되지 않음: Message " + i);
+		});
+	}
+
 }

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -1,0 +1,78 @@
+package eightplusone.bit.fit.domain.chat.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class ChatRepositoryTest {
+
+	@Autowired
+	private ChatRepository chatRepository;
+
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+
+	private static final String SESSION_ID = "testSession";
+
+	@BeforeEach
+	void setUp() {
+		// 테스트 전에 Redis에서 기존 데이터 삭제
+		chatRepository.clearChat(SESSION_ID);
+	}
+
+	@Test
+	void testChatMessageLimit() {
+		// 1100개의 메시지를 저장하여 1000개만 유지되는지 테스트
+		for (int i = 1; i <= 1100; i++) {
+			ChatMessage message = ChatMessage.builder()
+				.sessionId(SESSION_ID)
+				.userId("user" + i)
+				.message("Message " + i)
+				.build();
+			chatRepository.saveMessage(message);
+		}
+
+		// 저장된 메시지 개수 가져오기
+		List<Object> messages = chatRepository.getRecentMessages(SESSION_ID);
+
+		// 메시지가 1000개만 유지되는지 검증
+		assertEquals(1000, messages.size());
+
+		// 가장 오래된 메시지가 삭제되었는지 확인
+		assertFalse(messages.contains("Message 1")); // 첫 번째 메시지가 삭제되었어야 함
+	}
+
+	@Test
+	void testChatMessageExpiration() throws InterruptedException {
+		// 메시지 저장
+		ChatMessage message = ChatMessage.builder()
+			.sessionId(SESSION_ID)
+			.userId("user123")
+			.message("Test TTL")
+			.build();
+		chatRepository.saveMessage(message);
+
+		// TTL 설정 확인 (2시간 → 7200초)
+		Long ttl = redisTemplate.getExpire("chat-" + SESSION_ID);
+		assertNotNull(ttl);
+		assertTrue(ttl > 7100); // 2시간(7200초) 설정되었는지 확인
+
+		// TTL을 5초로 변경하여 삭제되는지 테스트
+		redisTemplate.expire("chat-" + SESSION_ID, Duration.ofSeconds(5));
+
+		// 6초 대기 후 데이터가 삭제되었는지 확인
+		Thread.sleep(6000);
+		assertFalse(chatRepository.existsBySessionId(SESSION_ID));
+	}
+}

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -5,13 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import jakarta.transaction.Transactional;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -34,16 +34,16 @@ public class ChatRepositoryTest {
 	@Autowired
 	private SessionRepository sessionRepository;
 
-	private static final Long SESSION_ID = 1L;
+	private Long sessionId;
 
 	@BeforeEach
 	void setUp() {
 		// 기존 데이터 삭제
-		chatRepository.clearChat(SESSION_ID.toString());
-		sessionRepository.deleteAll(); // 기존 세션 데이터 정리
+		chatRepository.clearChat(String.valueOf(sessionId));
+		sessionRepository.deleteAll();
 
-		// 테스트용 세션 미리 저장 (강연시간: 1시간)
-		Session testSession = Session.builder()
+		// ✅ 테스트용 세션 저장 후, 실제 저장된 ID 사용
+		Session testSession = sessionRepository.save(Session.builder()
 			.title("테스트 세션")
 			.sessionImage("test.jpg")
 			.summary("테스트용 강연")
@@ -51,18 +51,13 @@ public class ChatRepositoryTest {
 			.endTime(LocalDateTime.now().plusHours(1)) // 강연시간 1시간
 			.standardCount(100)
 			.audioChannel(2)
-			.build();
-		sessionRepository.save(testSession);
+			.build());
+		sessionRepository.flush(); // 🔹 강제 반영하여 삭제 방지
+		sessionId = testSession.getSessionId(); // 🔹 실제 저장된 ID 가져오기
 
-		// 저장 후 검증
-		Long count = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		// 저장 확인
+		Long count = redisTemplate.opsForList().size("chat-" + sessionId);
 		assertEquals(0, count, "clearChat() 이후에도 메시지가 남아 있음!");
-	}
-
-	@AfterEach
-	void tearDown() {
-		// 테스트 종료 후 세션 정리
-		sessionRepository.deleteAll();
 	}
 
 	@Test
@@ -70,7 +65,7 @@ public class ChatRepositoryTest {
 		// 1100개의 메시지를 저장하여 1000개만 유지되는지 테스트
 		for (int i = 1; i <= 1100; i++) {
 			ChatMessage message = ChatMessage.builder()
-				.sessionId(SESSION_ID)
+				.sessionId(sessionId)
 				.userId("user" + i)
 				.message("Message " + i)
 				.build();
@@ -78,7 +73,7 @@ public class ChatRepositoryTest {
 		}
 
 		// 저장된 메시지 개수 가져오기
-		List<Object> messages = chatRepository.getRecentMessages(SESSION_ID.toString());
+		List<Object> messages = chatRepository.getRecentMessages(sessionId.toString());
 
 		// 메시지가 1000개만 유지되는지 검증
 		assertEquals(1000, messages.size());
@@ -92,7 +87,7 @@ public class ChatRepositoryTest {
 	void testMessageTrimmingInRedis() {
 		for (int i = 1; i <= 1200; i++) { // 1200개 저장
 			ChatMessage message = ChatMessage.builder()
-				.sessionId(SESSION_ID)
+				.sessionId(sessionId)
 				.userId("user" + i)
 				.message("Message " + i)
 				.build();
@@ -100,7 +95,7 @@ public class ChatRepositoryTest {
 		}
 
 		// Redis에 저장된 메시지 개수 확인
-		Long messageCount = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		Long messageCount = redisTemplate.opsForList().size("chat-" + sessionId);
 		System.out.println("현재 Redis 저장된 메시지 개수: " + messageCount);
 
 		// Redis에 1000개만 남아 있는지 확인
@@ -109,9 +104,11 @@ public class ChatRepositoryTest {
 	}
 
 	@Test
+	@Transactional
+		// 🔹 자동 롤백 방지
 	void testChatMessageExpiration() throws InterruptedException {
 		// 테스트용 세션 가져오기
-		Session session = sessionRepository.findById(SESSION_ID).orElse(null);
+		Session session = sessionRepository.findById(sessionId).orElse(null);
 		assertNotNull(session, "테스트용 세션이 존재해야 합니다!");
 
 		// 강연시간(1시간) + 30분 TTL 계산
@@ -144,7 +141,7 @@ public class ChatRepositoryTest {
 	void testOldestMessagesAreDeleted() {
 		for (int i = 1; i <= 1100; i++) { // 1100개 저장
 			ChatMessage message = ChatMessage.builder()
-				.sessionId(SESSION_ID)
+				.sessionId(sessionId)
 				.userId("user" + i)
 				.message("Message " + i)
 				.build();
@@ -152,13 +149,13 @@ public class ChatRepositoryTest {
 		}
 
 		// Redis에 저장된 메시지 개수 직접 확인
-		Long messageCount = redisTemplate.opsForList().size("chat-" + SESSION_ID);
+		Long messageCount = redisTemplate.opsForList().size("chat-" + sessionId);
 		System.out.println("🔍 Redis에 저장된 메시지 개수: " + messageCount);
 		assertNotNull(messageCount);
 		assertEquals(1000, messageCount, "Redis에 저장된 메시지 개수가 1000개가 아님!");
 
 		// Redis에서 가져온 메시지를 Set으로 변환하여 빠르게 비교
-		List<Object> messages = redisTemplate.opsForList().range("chat-" + SESSION_ID, 0, -1);
+		List<Object> messages = redisTemplate.opsForList().range("chat-" + sessionId, 0, -1);
 		Set<String> messageSet = messages.stream()
 			.map(Object::toString)
 			.collect(Collectors.toSet());

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -43,7 +43,7 @@ class ChatServiceTest {
 
 	private ChatMessageDto chatMessageDto;
 	private ChatMessage chatMessage;
-	private final String sessionId = "testSession";
+	private final Long sessionId = 1L;
 	private final String userId = "testUser";
 	private final String messageId = "testMessage";
 	private final String timestamp = "testTimestamp";
@@ -71,7 +71,7 @@ class ChatServiceTest {
 	// 채팅 메시지를 성공적으로 저장하고 레디스에 발행되는지 확인
 	@Test
 	void sendMessage_success() throws JsonProcessingException {
-		when(chatRepository.existsBySessionId(sessionId)).thenReturn(true);
+		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
 		doNothing().when(chatRepository).saveMessage(any(ChatMessage.class));
 
 		chatService.sendMessage(chatMessageDto, userId, sessionId);
@@ -83,7 +83,7 @@ class ChatServiceTest {
 	// 존재하지 않는 세션에 메시지를 보내면 예외가 발생하는지 확인
 	@Test
 	void sendMessage_fails_whenSessionNotFound() {
-		when(chatRepository.existsBySessionId(sessionId)).thenReturn(false);
+		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(false);
 
 		CustomException exception = assertThrows(CustomException.class, () ->
 			chatService.sendMessage(chatMessageDto, userId, sessionId));
@@ -138,22 +138,22 @@ class ChatServiceTest {
 	// 특정 채팅방의 최근 메시지를 정상적으로 조회할 수 있는지 확인
 	@Test
 	void getRecentMessages_success() {
-		when(chatRepository.existsBySessionId(sessionId)).thenReturn(true);
-		when(chatRepository.getRecentMessages(sessionId)).thenReturn(List.of(chatMessage));
+		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
+		when(chatRepository.getRecentMessages(String.valueOf(sessionId))).thenReturn(List.of(chatMessage));
 
-		List<Object> messages = chatService.getRecentMessages(sessionId);
+		List<Object> messages = chatService.getRecentMessages(String.valueOf(sessionId));
 
 		assertThat(messages).isNotEmpty();
-		verify(chatRepository, times(1)).getRecentMessages(sessionId);
+		verify(chatRepository, times(1)).getRecentMessages(String.valueOf(sessionId));
 	}
 
 	// 존재하지 않는 세션의 메시지를 조회할 때 예외가 발생하는지 확인
 	@Test
 	void getRecentMessages_fails_whenSessionNotFound() {
-		when(chatRepository.existsBySessionId(sessionId)).thenReturn(false);
+		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(false);
 
 		CustomException exception = assertThrows(CustomException.class, () ->
-			chatService.getRecentMessages(sessionId));
+			chatService.getRecentMessages(String.valueOf(sessionId)));
 
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHAT_SESSION_NOT_FOUND);
 	}
@@ -162,11 +162,11 @@ class ChatServiceTest {
 	@Test
 	void getSortedQuestionMessages_success() {
 		// Given
-		when(chatRepository.existsBySessionId("session1")).thenReturn(true);
-		when(chatRepository.getRecentMessages("session1")).thenReturn(Arrays.asList(
-			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1", "1", "timestamp1"),
-			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2", "1", "timestamp2"),
-			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3", "1", "timestamp3")
+		when(chatRepository.existsBySessionId(String.valueOf(1L))).thenReturn(true);
+		when(chatRepository.getRecentMessages(String.valueOf(1L))).thenReturn(Arrays.asList(
+			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1", 1L, "timestamp1"),
+			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2", 1L, "timestamp2"),
+			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3", 1L, "timestamp3")
 		));
 
 		when(chatLikeRepository.getLikeCount("like:msg1")).thenReturn(10);
@@ -175,7 +175,7 @@ class ChatServiceTest {
 		when(userRedisRepository.getUserName("user2")).thenReturn("Bob");
 
 		// When
-		List<ChatMessageDto> sortedMessages = chatService.getSortedQuestionMessages("session1");
+		List<ChatMessageDto> sortedMessages = chatService.getSortedQuestionMessages(1L);
 
 		// Then
 		assertThat(sortedMessages).hasSize(2);
@@ -187,10 +187,10 @@ class ChatServiceTest {
 	@Test
 	void getSortedQuestionMessages_fails_whenSessionNotFound() {
 		// Given
-		when(chatRepository.existsBySessionId("session1")).thenReturn(false);
+		when(chatRepository.existsBySessionId(String.valueOf(1L))).thenReturn(false);
 
 		// When & Then
-		assertThatThrownBy(() -> chatService.getSortedQuestionMessages("session1"))
+		assertThatThrownBy(() -> chatService.getSortedQuestionMessages(1L))
 			.isInstanceOf(CustomException.class)
 			.hasMessage(ErrorCode.CHAT_SESSION_NOT_FOUND.getMessage());
 	}

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -54,7 +54,8 @@ class ChatServiceTest {
 			ChatCategory.GENERAL,
 			"Test message",
 			"Test User",
-			userId
+			userId,
+			sessionId
 		);
 
 		chatMessage = ChatMessage.builder()
@@ -161,9 +162,9 @@ class ChatServiceTest {
 		// Given
 		when(chatRepository.existsBySessionId("session1")).thenReturn(true);
 		when(chatRepository.getRecentMessages("session1")).thenReturn(Arrays.asList(
-			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1"),
-			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2"),
-			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3")
+			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1", "1"),
+			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2", "1"),
+			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3", "1")
 		));
 
 		when(chatLikeRepository.getLikeCount("like:msg1")).thenReturn(10);

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -46,6 +46,7 @@ class ChatServiceTest {
 	private final String sessionId = "testSession";
 	private final String userId = "testUser";
 	private final String messageId = "testMessage";
+	private final String timestamp = "testTimestamp";
 
 	@BeforeEach
 	void setUp() {
@@ -55,7 +56,8 @@ class ChatServiceTest {
 			"Test message",
 			"Test User",
 			userId,
-			sessionId
+			sessionId,
+			timestamp
 		);
 
 		chatMessage = ChatMessage.builder()
@@ -162,9 +164,9 @@ class ChatServiceTest {
 		// Given
 		when(chatRepository.existsBySessionId("session1")).thenReturn(true);
 		when(chatRepository.getRecentMessages("session1")).thenReturn(Arrays.asList(
-			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1", "1"),
-			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2", "1"),
-			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3", "1")
+			new ChatMessageDto("msg1", ChatCategory.QUESTION, "Question 1", "Alice", "user1", "1", "timestamp1"),
+			new ChatMessageDto("msg2", ChatCategory.QUESTION, "Question 2", "Bob", "user2", "1", "timestamp2"),
+			new ChatMessageDto("msg3", ChatCategory.GENERAL, "General message", "Charlie", "user3", "1", "timestamp3")
 		));
 
 		when(chatLikeRepository.getLikeCount("like:msg1")).thenReturn(10);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#53 ]

### 로컬 병합
X

### 변경 사항
1. 채팅 메시지 유지개수는 1000개 그대로 유지하는 것으로 결정했습니다.
2. TTL이 2시간에서 강연시간+30분으로 변경되었습니다.
3. 세션 엔티티에 강연시간 필드 추가하였습니다.
4. 코드 변경으로 서비스테스트와 레포지토리테스트 에러 수정하여 테스트 통과했습니다.
5. 레포지토리 테스트의 testOldestMessagesAreDeleted 메서드는 특정 메시지가 삭제되었는지 직접 조회해보는 테스트입니다. 그러나 현재 ChatMessage 엔티티 코드에는 name 필드가 존재하지 않고 ChatMessageDto 코드에는 name 필드가 존재하는데, 이 때문에 역직렬화 문제가 발생하여 테스트가 통과되지 않았습니다. 이를 해결하기 위해 엔티티 코드에 name 필드를 추가하는 방법도 있으나 현재 성능 최적화를 위해 userId와 name을 매핑하여 구현 해놓은 상태이기에 엔티티 코드에 name 필드를 추가하지 않을 계획이라 해당 테스트를 @Disabled 처리 해두었습니다. **테스트를 통과하지 않은 것은 구현의 문제가 아닌 단순 역직렬화 문제이며 다른 테스트에서 정상 작동함을 모두 확인하였기 때문에 이상 없습니다. 추후 필요한 경우가 생기면 사용하기 위해 완전히 삭제하지는 않았습니다.**

### 테스트 결과
ChatServiceTest
![chat service test](https://github.com/user-attachments/assets/668b40b2-18ae-4d83-b445-a23980ccc5d7)
ChatRepositoryTest
![chatrepository test](https://github.com/user-attachments/assets/80b5e816-2454-4f93-8535-b38e26e985c9)
