### PR TITLE
[#61] 현재 진행중인 강연조회

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -2,6 +2,8 @@ package eightplusone.bit.fit.domain.session.controller;
 
 import static org.springframework.http.HttpStatus.*;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -26,7 +28,7 @@ public class SessionController {
 
 	private final SessionService sessionService;
 
-	@Operation(summary = "세션 전체 조회", description = "**성공 응답 데이터:**  세션 전체 리스트")
+	@Operation(summary = "세션 전체 조회 및 필터링", description = "**성공 응답 데이터:**  세션 전체 리스트")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "세션 전체 조회 성공"),
 	})
@@ -35,5 +37,15 @@ public class SessionController {
 		TagDto dto) {
 		return ResponseEntity.status(OK)
 			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList(pageable, dto)));
+	}
+
+	@Operation(summary = "라이브 중인 전체 조회", description = "**성공 응답 데이터:**  라이브 중인 세션 리스트")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "라이브 중인 세션 조회 성공"),
+	})
+	@GetMapping("/live")
+	public ResponseEntity<ResponseDto<List<SessionListResponseDto>>> onLiveSessions() {
+		return ResponseEntity.status(OK)
+			.body(ResponseDto.success(OK, "라이브 중인 세션 리스트 조회 성공", sessionService.getLiveSessions()));
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/controller/SessionController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.service.SessionService;
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import eightplusone.bit.fit.global.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -32,7 +32,7 @@ public class SessionController {
 	})
 	@GetMapping("/all")
 	public ResponseEntity<ResponseDto<Page<SessionListResponseDto>>> all(@PageableDefault(size = 9) Pageable pageable,
-		TagResponseDto dto) {
+		TagDto dto) {
 		return ResponseEntity.status(OK)
 			.body(ResponseDto.success(OK, "세션 전체 리스트 조회 성공", sessionService.getSessionsList(pageable, dto)));
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
@@ -2,7 +2,7 @@ package eightplusone.bit.fit.domain.session.dto;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,9 +22,9 @@ public class SessionListResponseDto {
 
 	private SpeakerResponseDto speaker;
 
-	private TagResponseDto tags;
+	private TagDto tags;
 
-	public static SessionListResponseDto from(Session session, SpeakerResponseDto speaker, TagResponseDto tags) {
+	public static SessionListResponseDto from(Session session, SpeakerResponseDto speaker, TagDto tags) {
 		return SessionListResponseDto.builder()
 			.id(session.getSessionId())
 			.title(session.getTitle())

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
-public interface SessionRepository extends JpaRepository<Session, Long> {
+public interface SessionRepository extends JpaRepository<Session, Long>, SessionRepositoryCustom {
 	Optional<Session> findByAudioChannel(Integer audioChannel);
 
 	Page<Session> findAll(Pageable pageable);

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,12 +1,10 @@
 package eightplusone.bit.fit.domain.session.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
@@ -14,7 +12,4 @@ public interface SessionRepository extends JpaRepository<Session, Long>, Session
 	Optional<Session> findByAudioChannel(Integer audioChannel);
 
 	Page<Session> findAll(Pageable pageable);
-
-	@Query("SELECT s FROM Session s WHERE s.startTime <= CURRENT_TIMESTAMP AND s.endTime >= CURRENT_TIMESTAMP")
-	List<Session> findLiveSessions();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,10 +1,12 @@
 package eightplusone.bit.fit.domain.session.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
 
@@ -12,4 +14,7 @@ public interface SessionRepository extends JpaRepository<Session, Long>, Session
 	Optional<Session> findByAudioChannel(Integer audioChannel);
 
 	Page<Session> findAll(Pageable pageable);
+
+	@Query("SELECT s FROM Session s WHERE s.startTime <= CURRENT_TIMESTAMP AND s.endTime >= CURRENT_TIMESTAMP")
+	List<Session> findLiveSessions();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
@@ -3,8 +3,8 @@ package eightplusone.bit.fit.domain.session.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 
 public interface SessionRepositoryCustom {
-	Page<Object[]> tagFilterAndSearch(Pageable pageable, TagResponseDto dto);
+	Page<Object[]> tagFilterAndSearch(Pageable pageable, TagDto dto);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
@@ -1,5 +1,7 @@
 package eightplusone.bit.fit.domain.session.repository;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -7,4 +9,6 @@ import eightplusone.bit.fit.domain.tag.dto.TagDto;
 
 public interface SessionRepositoryCustom {
 	Page<Object[]> tagFilterAndSearch(Pageable pageable, TagDto dto);
+
+	List<Object[]> findLiveSessionsWithSpeakerAndTag();
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryCustom.java
@@ -1,10 +1,10 @@
-package eightplusone.bit.fit.domain.tag.repository;
+package eightplusone.bit.fit.domain.session.repository;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
 
-public interface TagRepositoryCustom {
+public interface SessionRepositoryCustom {
 	Page<Object[]> tagFilterAndSearch(Pageable pageable, TagResponseDto dto);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
@@ -17,7 +17,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -27,7 +27,7 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<Object[]> tagFilterAndSearch(Pageable pageable, TagResponseDto dto) {
+	public Page<Object[]> tagFilterAndSearch(Pageable pageable, TagDto dto) {
 		List<Tuple> results = queryFactory
 			.select(session, tag, speaker)
 			.from(session)

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
@@ -4,6 +4,7 @@ import static eightplusone.bit.fit.domain.session.entity.QSession.*;
 import static eightplusone.bit.fit.domain.speaker.entity.QSpeaker.*;
 import static eightplusone.bit.fit.domain.tag.entity.QTag.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -76,5 +77,22 @@ public class SessionRepositoryImpl implements SessionRepositoryCustom {
 
 	public static BooleanExpression containLevel(String level) {
 		return StringUtils.hasText(level) ? tag.level.eq(level) : null;
+	}
+
+	@Override
+	public List<Object[]> findLiveSessionsWithSpeakerAndTag() {
+		LocalDateTime now = LocalDateTime.now();
+
+		List<Tuple> result = queryFactory
+			.select(session, speaker, tag)
+			.from(session)
+			.leftJoin(speaker).on(speaker.session.eq(session))
+			.leftJoin(tag).on(tag.session.eq(session))
+			.where(session.startTime.loe(now), session.endTime.goe(now))
+			.fetch();
+
+		return result.stream()
+			.map(tuple -> new Object[] {tuple.get(session), tuple.get(speaker), tuple.get(tag)})
+			.toList();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepositoryImpl.java
@@ -1,4 +1,4 @@
-package eightplusone.bit.fit.domain.tag.repository;
+package eightplusone.bit.fit.domain.session.repository;
 
 import static eightplusone.bit.fit.domain.session.entity.QSession.*;
 import static eightplusone.bit.fit.domain.speaker.entity.QSpeaker.*;
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class TagRepositoryImpl implements TagRepositoryCustom {
+public class SessionRepositoryImpl implements SessionRepositoryCustom {
 
 	private final JPAQueryFactory queryFactory;
 

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -16,7 +16,7 @@ import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -101,14 +101,14 @@ public class SessionService {
 		}
 	}
 
-	public Page<SessionListResponseDto> getSessionsList(Pageable pageable, TagResponseDto tagDto) {
+	public Page<SessionListResponseDto> getSessionsList(Pageable pageable, TagDto tagDto) {
 		Page<Object[]> sessions = sessionRepository.tagFilterAndSearch(pageable, tagDto);
 
 		return sessions.map(session -> {
 			return SessionListResponseDto.from(
 				(Session)session[0],
 				SpeakerResponseDto.from((Speaker)session[2]),
-				TagResponseDto.from((Tag)session[1])
+				TagDto.from((Tag)session[1])
 			);
 		});
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -16,8 +16,10 @@ import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
+import eightplusone.bit.fit.domain.tag.repository.TagRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
@@ -29,6 +31,8 @@ public class SessionService {
 	private final SessionRepository sessionRepository;
 	private final String SESSION_CONGESTION_KEY = "session_congestion";
 	private final String SESSION_USER_KEY = "session_user";
+	private final SpeakerRepository speakerRepository;
+	private final TagRepository tagRepository;
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
@@ -111,5 +115,17 @@ public class SessionService {
 				TagDto.from((Tag)session[1])
 			);
 		});
+	}
+
+	public List<SessionListResponseDto> getLiveSessions() {
+		List<Object[]> sessions = sessionRepository.findLiveSessionsWithSpeakerAndTag();
+
+		return sessions.stream().map(session -> {
+			return SessionListResponseDto.from(
+				(Session)session[0],
+				SpeakerResponseDto.from((Speaker)session[1]),
+				TagDto.from((Tag)session[2])
+			);
+		}).toList();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -16,10 +16,8 @@ import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
-import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
-import eightplusone.bit.fit.domain.tag.repository.TagRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
@@ -31,8 +29,6 @@ public class SessionService {
 	private final SessionRepository sessionRepository;
 	private final String SESSION_CONGESTION_KEY = "session_congestion";
 	private final String SESSION_USER_KEY = "session_user";
-	private final SpeakerRepository speakerRepository;
-	private final TagRepository tagRepository;
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -16,10 +16,8 @@ import eightplusone.bit.fit.domain.session.entity.enums.CongestionLevel;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.dto.SpeakerResponseDto;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
-import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
-import eightplusone.bit.fit.domain.tag.repository.TagRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
@@ -31,8 +29,6 @@ public class SessionService {
 	private final SessionRepository sessionRepository;
 	private final String SESSION_CONGESTION_KEY = "session_congestion";
 	private final String SESSION_USER_KEY = "session_user";
-	private final TagRepository tagRepository;
-	private final SpeakerRepository speakerRepository;
 
 	// TODO: User ID 매개변수 부분 -> 토큰으로 수정
 	// 체크인 시 레디스에 저장
@@ -106,7 +102,7 @@ public class SessionService {
 	}
 
 	public Page<SessionListResponseDto> getSessionsList(Pageable pageable, TagResponseDto tagDto) {
-		Page<Object[]> sessions = tagRepository.tagFilterAndSearch(pageable, tagDto);
+		Page<Object[]> sessions = sessionRepository.tagFilterAndSearch(pageable, tagDto);
 
 		return sessions.map(session -> {
 			return SessionListResponseDto.from(

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 
 public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
-	Speaker findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/service/SpeakerService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/service/SpeakerService.java
@@ -1,7 +1,0 @@
-package eightplusone.bit.fit.domain.speaker.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class SpeakerService {
-}

--- a/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-@Schema(name = "TagResponseDto: 태그 정보 응답 dto")
+@Schema(name = "TagDto: 태그 정보 응답 및 필터링에 사용되 dto")
 public class TagDto {
 	private String field;
 

--- a/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/dto/TagDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @Schema(name = "TagResponseDto: 태그 정보 응답 dto")
-public class TagResponseDto {
+public class TagDto {
 	private String field;
 
 	private String topic;
@@ -17,8 +17,8 @@ public class TagResponseDto {
 
 	private String level;
 
-	public static TagResponseDto from(Tag tag) {
-		return TagResponseDto.builder()
+	public static TagDto from(Tag tag) {
+		return TagDto.builder()
 			.field(tag.getField())
 			.topic(tag.getTopic())
 			.type(tag.getType())

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 
-public interface TagRepository extends JpaRepository<Tag, Long>, TagRepositoryCustom {
+public interface TagRepository extends JpaRepository<Tag, Long> {
 	Tag findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/repository/TagRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-	Tag findBySession_SessionId(Long sessionId);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/tag/service/TagService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/tag/service/TagService.java
@@ -1,7 +1,0 @@
-package eightplusone.bit.fit.domain.tag.service;
-
-import org.springframework.stereotype.Service;
-
-@Service
-public class TagService {
-}

--- a/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
+++ b/src/main/java/eightplusone/bit/fit/global/enums/ApiEndpoint.java
@@ -14,7 +14,7 @@ public enum ApiEndpoint {
 		"/call",
 		"/ws",
 		"/ws/**",
-		"/api/v1/session/all"
+		"/api/v1/session/**"
 	}),
 
 	PUBLIC_POST(HttpMethod.POST, new String[] {

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -29,7 +29,6 @@ import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
-import eightplusone.bit.fit.domain.tag.repository.TagRepository;
 import eightplusone.bit.fit.support.fixture.SessionFixture;
 import eightplusone.bit.fit.support.fixture.SpeakerFixture;
 import eightplusone.bit.fit.support.fixture.TagFixture;
@@ -48,8 +47,8 @@ class SessionServiceTest {
 	@InjectMocks
 	private SessionService sessionService;
 
-	@Mock
-	private TagRepository tagRepository;
+	// @Mock
+	// private TagRepository tagRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -159,7 +158,7 @@ class SessionServiceTest {
 
 		long count = filteredData.size();
 
-		when(tagRepository.tagFilterAndSearch(pageable, tagDto))
+		when(sessionRepository.tagFilterAndSearch(pageable, tagDto))
 			.thenReturn(new PageImpl<>(filteredData, pageable, count));
 
 		// when
@@ -219,7 +218,7 @@ class SessionServiceTest {
 
 		Page<Object[]> mockPage = new PageImpl<>(mockData, pageable, mockData.size());
 
-		when(tagRepository.tagFilterAndSearch(pageable, null)).thenReturn(mockPage);
+		when(sessionRepository.tagFilterAndSearch(pageable, null)).thenReturn(mockPage);
 
 		// when
 		Page<SessionListResponseDto> result = sessionService.getSessionsList(pageable, null);

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -27,7 +27,7 @@ import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
-import eightplusone.bit.fit.domain.tag.dto.TagResponseDto;
+import eightplusone.bit.fit.domain.tag.dto.TagDto;
 import eightplusone.bit.fit.domain.tag.entity.Tag;
 import eightplusone.bit.fit.support.fixture.SessionFixture;
 import eightplusone.bit.fit.support.fixture.SpeakerFixture;
@@ -146,7 +146,7 @@ class SessionServiceTest {
 
 		Tag tag1 = TagFixture.TAG_FIXTURE_1.createTag();
 
-		TagResponseDto tagDto = TagResponseDto.from(tag1);
+		TagDto tagDto = TagDto.from(tag1);
 
 		List<Object[]> mockData = new ArrayList<>();
 		mockData.add(new Object[] {session1, tag1, speaker1});

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -47,9 +47,6 @@ class SessionServiceTest {
 	@InjectMocks
 	private SessionService sessionService;
 
-	// @Mock
-	// private TagRepository tagRepository;
-
 	@BeforeEach
 	void setUp() {
 		MockitoAnnotations.openMocks(this);
@@ -253,6 +250,44 @@ class SessionServiceTest {
 			() -> assertThat(content.get(5).getTitle()).isEqualTo(session6.getTitle()),
 			() -> assertThat(content.get(5).getSpeaker().getName()).isEqualTo(speaker6.getName()),
 			() -> assertThat(content.get(5).getTags().getField()).isEqualTo(tag6.getField())
+		);
+	}
+
+	@Test
+	@DisplayName("라이브 중인 세션을 조회한다")
+	void getLiveSessions() {
+		// given
+		Session session1 = SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession();
+		Session session2 = SessionFixture.SESSION_STAGE_1_FIXTURE_2.createSession();
+
+		Speaker speaker1 = SpeakerFixture.SPEAKER_FIXTURE_1.createSpeaker();
+		Speaker speaker2 = SpeakerFixture.SPEAKER_FIXTURE_2.createSpeaker();
+
+		Tag tag1 = TagFixture.TAG_FIXTURE_1.createTag();
+		Tag tag2 = TagFixture.TAG_FIXTURE_2.createTag();
+
+		List<Object[]> mockData = List.of(
+			new Object[] {session1, speaker1, tag1},
+			new Object[] {session2, speaker2, tag2}
+		);
+
+		when(sessionRepository.findLiveSessionsWithSpeakerAndTag()).thenReturn(mockData);
+
+		// when
+		List<SessionListResponseDto> result = sessionService.getLiveSessions();
+
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result).hasSize(2);
+
+		assertAll(
+			() -> assertThat(result.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(result.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
+			() -> assertThat(result.get(0).getTags().getField()).isEqualTo(tag1.getField()),
+
+			() -> assertThat(result.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(result.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
+			() -> assertThat(result.get(1).getTags().getField()).isEqualTo(tag2.getField())
 		);
 	}
 }

--- a/src/test/java/eightplusone/bit/fit/support/fixture/SessionFixture.java
+++ b/src/test/java/eightplusone/bit/fit/support/fixture/SessionFixture.java
@@ -11,9 +11,9 @@ public enum SessionFixture {
 	 * 1부 세션 1,2,3
 	 */
 	SESSION_STAGE_1_FIXTURE_1("1부 세션1 09:50-10:50", "백엔드 잘하는 법", "image1_1.png",
-		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 100, 2),
+		LocalDateTime.now(), LocalDateTime.now().plusHours(3), 100, 2),
 	SESSION_STAGE_1_FIXTURE_2("1부 세션2 09:50-10:50", "프론트엔드 마스터하기", "image1_2.png",
-		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 50, 1),
+		LocalDateTime.now(), LocalDateTime.now().plusHours(3), 50, 1),
 	SESSION_STAGE_1_FIXTURE_3("1부 세션3 09:50-10:50", "데이터베이스 성능 최적화", "image1_3.png",
 		LocalDateTime.of(2024, 4, 2, 9, 50), LocalDateTime.of(2024, 4, 2, 10, 50), 70, 3),
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
- closed. #61 

### 변경 사항
1. 현재 진행중인 강연조회 구현
- 세션, 태그, 연사 각각 조회하려고 하니 N+1가 발생할 수 있다고하여 기존 작성해둔 QueryDSL로 현재 진행중인 강연조회를 구현했습니다.
- TagRepositoryCustom, TagRepositoryImpl 파일명을 Session으로 통일했습니다. 태그로 조회하는 것은 맞지만, 세션을 조회하는 것이기에 세션으로 통일하는것이 더 직관적이라고 판단하여 변경했습니다.

### 테스트 결과
1. Swagger 테스트 결과
<img width="964" alt="스크린샷 2025-03-20 오후 3 13 07" src="https://github.com/user-attachments/assets/bae6b834-1f61-49c3-8fa4-26089820e084" />

</br>
</br>

2. 테스트 코드 통과
<img width="389" alt="스크린샷 2025-03-20 오후 3 39 40" src="https://github.com/user-attachments/assets/0e91d96b-e12a-46b3-9fc7-04fc1efd4ac3" />
