### PR TITLE
[#75] 오디오 스트리밍 혼잡도 연결

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/entity/Session.java
@@ -1,5 +1,10 @@
 package eightplusone.bit.fit.domain.session.entity;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import eightplusone.bit.fit.domain.mysession.entity.MySession;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -9,10 +14,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -50,6 +51,9 @@ public class Session {
 	@Column(nullable = false)
 	private Long lectureDuration; // 강연 시간 (초 단위)
 
+	@Column(nullable = false)
+	private Boolean isLive;
+
 	@OneToMany(mappedBy = "session", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<MySession> mySessions = new ArrayList<>();
 
@@ -64,6 +68,7 @@ public class Session {
 		this.standardCount = standardCount;
 		this.audioChannel = audioChannel;
 		this.lectureDuration = Duration.between(startTime, endTime).getSeconds(); // 강연 시간 저장
+		this.isLive = false;
 	}
 
 	// 강연 시간이 변경될 경우 업데이트

--- a/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/repository/SessionRepository.java
@@ -1,15 +1,27 @@
 package eightplusone.bit.fit.domain.session.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.session.entity.Session;
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface SessionRepository extends JpaRepository<Session, Long>, SessionRepositoryCustom {
 	Optional<Session> findByAudioChannel(Integer audioChannel);
 
 	Page<Session> findAll(Pageable pageable);
+
+	List<Session> findByIsLiveTrue();
+
+	@Modifying
+	@Query("""
+		update Session s set s.isLive = :isLive where s.audioChannel = :audioChannel
+		""")
+	void updateIsLiveByAudioChannel(@Param("audioChannel") Integer audioChannel, @Param("isLive") boolean isLive);
 }

--- a/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/service/SessionService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import eightplusone.bit.fit.domain.session.dto.SessionListResponseDto;
 import eightplusone.bit.fit.domain.session.entity.Session;
@@ -44,7 +45,7 @@ public class SessionService {
 
 	// 혼잡도 전송
 	public Map<Integer, Map<String, Object>> getUpdatedSessionData() {
-		List<Session> sessions = sessionRepository.findAll();
+		List<Session> sessions = sessionRepository.findByIsLiveTrue();
 		HashOperations<String, String, String> hashOps = redisTemplate.opsForHash();
 
 		return sessions.stream()
@@ -123,5 +124,26 @@ public class SessionService {
 				TagDto.from((Tag)session[2])
 			);
 		}).toList();
+	}
+
+	public void updateSessionUserAudioChannel(String email, Integer audioChannel) {
+		String value = audioChannel == null ? "null" : audioChannel.toString();
+		redisTemplate.opsForHash().put(SESSION_USER_KEY, email, value);
+	}
+
+	@Transactional
+	public void deleteSessionData(Integer audioChannel) {
+		redisTemplate.opsForHash().entries(SESSION_USER_KEY)
+			.forEach((key, value) -> {
+				if (value.toString().equals(audioChannel.toString())) {
+					redisTemplate.opsForHash().put(SESSION_USER_KEY, key, "null");
+				}
+			});
+		sessionRepository.updateIsLiveByAudioChannel(audioChannel, false);
+	}
+
+	@Transactional
+	public void activateSessionLive(Integer audioChannel) {
+		sessionRepository.updateIsLiveByAudioChannel(audioChannel, true);
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/streaming/service/RoomService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/streaming/service/RoomService.java
@@ -73,6 +73,8 @@ public class RoomService {
 		// ICE candidate 수신 대기
 		presenterEndpoint.gatherCandidates();
 
+		// 세션 라이브 상태 반영
+		sessionService.activateSessionLive(Integer.valueOf(roomId));
 		return sdpAnswer;
 	}
 
@@ -119,6 +121,11 @@ public class RoomService {
 
 		String sdpAnswer = audienceEndpoint.processOffer(sdpOffer);
 		audienceEndpoint.gatherCandidates();
+
+		// 청중 입장 혼잡도 최신화
+		Integer audioChannel = Integer.valueOf(roomId);
+		sessionService.updateSessionUserAudioChannel(audienceEmail, audioChannel);
+		sessionService.updateAndBroadcastIfChanged(audioChannel);
 		return sdpAnswer;
 	}
 
@@ -157,6 +164,9 @@ public class RoomService {
 			room.getPipeline().release();
 			rooms.remove(roomId);
 			log.info("[Room] Removed room {} because presenter left and all audience endpoints were released.", roomId);
+
+			// 혼잡도 데이터 초기화
+			sessionService.deleteSessionData(Integer.valueOf(roomId));
 		}
 	}
 
@@ -169,6 +179,10 @@ public class RoomService {
 				endpoint.release();
 				room.getAudienceEndpoints().remove(audienceEmail);
 				log.info("[Audience] Released audience endpoint for {} in room: {}", audienceEmail, roomId);
+
+				// 청중 퇴장 혼잡도 최신화
+				sessionService.updateSessionUserAudioChannel(audienceEmail, null);
+				sessionService.updateAndBroadcastIfChanged(Integer.valueOf(roomId));
 			}
 			// 발표자도 없고 청중도 없으면 MediaPipeline 해제 후 방 제거
 			if (room.getPresenterEndpoint() == null && room.getAudienceEndpoints().isEmpty()) {
@@ -178,5 +192,4 @@ public class RoomService {
 			}
 		}
 	}
-
 }

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -86,7 +86,7 @@ class SessionServiceTest {
 		setField(session, "audioChannel", 123);
 		setField(session, "standardCount", 10);
 
-		when(sessionRepository.findAll()).thenReturn(List.of(session));
+		when(sessionRepository.findByIsLiveTrue()).thenReturn(List.of(session));
 		when(sessionRepository.findByAudioChannel(123)).thenReturn(Optional.of(session));
 
 		when(hashOperations.values("session_user")).thenReturn(List.of("123", "123")); // 2명 접속
@@ -289,5 +289,53 @@ class SessionServiceTest {
 			() -> assertThat(result.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
 			() -> assertThat(result.get(1).getTags().getField()).isEqualTo(tag2.getField())
 		);
+	}
+
+	@Test
+	@DisplayName("청중의 현재 오디오 채널값을 업데이트한다")
+	void updateSessionUserAudioChannel() {
+		// given
+		String email = "test@gmail.com";
+		Integer audioChannel = 1;
+
+		// when
+		sessionService.updateSessionUserAudioChannel(email, audioChannel);
+
+		// then
+		verify(hashOperations).put("session_user", email, "1");
+	}
+
+	@Test
+	@DisplayName("청중의 오디오 채널값 초기화 및 세션의 라이브 상태를 false로 변경한다")
+	void deleteSessionData() {
+		// given
+		Integer audioChannel = 1;
+
+		Map<Object, Object> sessionUserMap = Map.of(
+			"test@gmail.com", "1",
+			"test2@gmail.com", "2"
+		);
+
+		when(hashOperations.entries("session_user")).thenReturn(sessionUserMap);
+
+		// when
+		sessionService.deleteSessionData(audioChannel);
+
+		// then
+		verify(hashOperations).put("session_user", "test@gmail.com", "null");
+		verify(sessionRepository).updateIsLiveByAudioChannel(audioChannel, false);
+	}
+
+	@Test
+	@DisplayName("세션을 라이브 상태로 변경한다")
+	void activateSessionLive() {
+		// give
+		Integer audioChannel = 1;
+
+		// when
+		sessionService.activateSessionLive(audioChannel);
+
+		// then
+		verify(sessionRepository).updateIsLiveByAudioChannel(audioChannel, true);
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#75]

### 배경
![스크린샷 2025-03-24 오후 1 06 34](https://github.com/user-attachments/assets/69afa80c-d286-4968-9284-24dacc4daf1b)
3번 세션만을 이용하여 테스트하는 중인데, 다른 세션의 혼잡도를 분석하기 위해 많은 쿼리가 나가고 있었습니다.
"강연 미진행 상태는 복잡도가 노출되지 않는 게 맞을 것 같다" 라는 결론을 바탕으로 진행하였습니다.

### 변경 사항

- 세션 시작 전에도 응답되던 혼잡도를 IsLive 필드를 통해 응답하지 않도록 했습니다.
- 청취자 입퇴장 시 SESSION_USER_KEY에 해당하는 value를 업데이트 합니다.
- 강연자 입장 시 isLive를 활성화하여, 혼잡도 응답을 시작하도록 했습니다.
- 강연자 퇴장 시 모든 청취자의 SESSION_USER_KEY에 해당하는 value를 null로 업데이트 하며, isLive를 비활성화하여 혼잡도 응답을 방지합니다.



### 테스트 결과

#### [API 테스트]
![라이브 엑티브 된거 없을때](https://github.com/user-attachments/assets/a281ceb9-f3a3-4080-82a1-556db493eb15)
행사 전 세션이 시작되지 않을 때는 혼잡도를 분석하지 않습니다.

![스피커 입장 여유 표시됨](https://github.com/user-attachments/assets/f5702ac5-0e78-4030-a58e-ff492c0ca980)
강연자가 입장하자, 혼잡도가 분석이 됩니다.

![청중 입장함](https://github.com/user-attachments/assets/fa637fa5-8fa6-4d1e-a8c4-e45809fff757)
청취자가 입장하자, 혼잡도 percent값의 변경이 일어납니다.

![청중이 나감](https://github.com/user-attachments/assets/a8fe21c0-2ac4-45f6-817c-2686838ddf0b)
청취자가 나가자, 혼잡도 percent값은 다시 0으로 줄어듭니다.

![다시 청중 입장](https://github.com/user-attachments/assets/e37f0edf-3707-4dc3-bd8c-34d5cdeecd45)
다시 청취자를 입장 시켰습니다.

![스피커가 나가버림](https://github.com/user-attachments/assets/46829214-17b6-46c6-ad00-ab82a9a5c022)
강연자가 퇴장해버리자, 모든 청중은 나가지고 혼잡도는 분석은 되지 않습니다.

[Service 테스트]
![스크린샷 2025-03-24 오후 3 44 01](https://github.com/user-attachments/assets/a20c4184-484a-46b5-b1d7-3de97ba0c671)
SessionServiceTest 결과