### PR TITLE
[#42] 계정 정보 조회 시 프로필 이미지도 함께 응답

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserAccountResponseDto.java
@@ -12,17 +12,21 @@ public class UserAccountResponseDto {
 	private final String name;
 	@Schema(description = "사용자 이메일", example = "test@gmail.com")
 	private final String email;
+	@Schema(description = "사용자 프로필 이미지", example = "https://12341234.s3.ap-northeast-2.amazonaws.com/12341234_profile.jpg ")
+	private final String imageUrl;
 
 	@Builder
-	private UserAccountResponseDto(String name, String email) {
+	private UserAccountResponseDto(String name, String email, String imageUrl) {
 		this.name = name;
 		this.email = email;
+		this.imageUrl = imageUrl;
 	}
 
-	public static UserAccountResponseDto of(String name, String email) {
+	public static UserAccountResponseDto of(String name, String email, String imageUrl) {
 		return UserAccountResponseDto.builder()
 			.name(name)
 			.email(email)
+			.imageUrl(imageUrl)
 			.build();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/service/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
 
 	public UserAccountResponseDto getAccountInfo(String email) {
 		User user = userRepository.findLoginUserByEmail(email);
-		return UserAccountResponseDto.of(user.getName(), user.getEmail());
+		return UserAccountResponseDto.of(user.getName(), user.getEmail(), user.getImageUrl());
 	}
 
 	public UserProfileResponseDto getProfileInfo(String email) {

--- a/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/user/service/UserServiceTest.java
@@ -71,7 +71,10 @@ class UserServiceTest {
 	@DisplayName("회원 계정 정보를 조회한다")
 	void userAccountGet() {
 		//given
+		String profileImageName = "imageName";
+		String profileImageUrl = "imageUrl";
 		User user = UserFixture.USER_FIXTURE_1.createUser();
+		user.updateProfileImage(profileImageName, profileImageUrl);
 
 		Mockito.when(userRepository.findLoginUserByEmail(user.getEmail())).thenReturn(user);
 
@@ -81,7 +84,8 @@ class UserServiceTest {
 		//then
 		assertAll(
 			() -> assertThat(accountInfo.getName()).isEqualTo(user.getName()),
-			() -> assertThat(accountInfo.getEmail()).isEqualTo(user.getEmail())
+			() -> assertThat(accountInfo.getEmail()).isEqualTo(user.getEmail()),
+			() -> assertThat(accountInfo.getImageUrl()).isEqualTo(user.getImageUrl())
 		);
 	}
 
@@ -175,7 +179,7 @@ class UserServiceTest {
 			MyInterest.of(interest3, user));
 
 		Mockito.when(myInterestRepository.saveAll(any())).thenReturn(myInterests);
-		
+
 		//when
 		userService.updateProfileInfo(user.getEmail(), userProfileUpdateRequestDto);
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#42]

### 변경 사항
계정정보 조회 시 프로필 이미지를 함께 받아보고 싶다는 프론트 측 요청으로 수정하였습니다 !

### 테스트 결과
[service 테스트]
![스크린샷 2025-03-25 오후 3 58 39](https://github.com/user-attachments/assets/d50225f5-a251-436b-9264-b08a9c984cf0)

[API 테스트]

![스크린샷 2025-03-25 오후 4 00 10](https://github.com/user-attachments/assets/3dacab48-895f-496b-8ad5-892cf85fb289)
프로필 사진이 있는 유저

![스크린샷 2025-03-25 오후 4 05 53](https://github.com/user-attachments/assets/68e8ddc0-8c15-46db-86b3-b763f233879a)
프로필 사진이 없는 유저

