### PR TITLE
[#85] Redis List -> ZSet 리팩터링

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -9,8 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.Header;
@@ -104,12 +102,15 @@ public class ChatController {
 		return ResponseEntity.ok(hasLiked);
 	}
 
-	@Operation(summary = "전체 질문 목록 조회", description = "특정 세션의 모든 질문 메시지를 좋아요 순으로 페이징 처리하여 반환합니다.")
-	@GetMapping("/questions/{sessionId}/all")
-	public Page<ChatMessageDto> getAllQuestions(
-		@Parameter(description = "세션 ID") @PathVariable String sessionId,
-		Pageable pageable
+	@Operation(summary = "ZSet 기반 좋아요 정렬 질문 페이징", description = "ZSet으로 좋아요 순으로 정렬된 질문을 페이징하여 반환합니다.")
+	@GetMapping("/questions/zset/{sessionId}")
+	public ResponseEntity<List<ChatMessageDto>> getZSetSortedQuestions(
+		@PathVariable Long sessionId,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "3") int size
 	) {
-		return chatService.getAllQuestionMessages(Long.valueOf(sessionId), pageable);
+		List<ChatMessageDto> result = chatService.getZSetSortedQuestions(sessionId, page, size);
+		return ResponseEntity.ok(result);
 	}
+
 }

--- a/src/main/java/eightplusone/bit/fit/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/entity/ChatMessage.java
@@ -33,7 +33,8 @@ public class ChatMessage {
 
 	// 기존 메시지를 새로 저장할 때 사용하는 생성자
 	@Builder
-	public ChatMessage(Long sessionId, String userId, ChatCategory category, String message) {
+	public ChatMessage(String messageId, Long sessionId, String userId, ChatCategory category, String message,
+		LocalDateTime timestamp) {
 		this.messageId = UUID.randomUUID().toString();
 		this.sessionId = sessionId;
 		this.userId = userId;

--- a/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepository.java
@@ -19,8 +19,12 @@ public class ChatLikeRepository {
 	}
 
 	// 좋아요 취소
-	public void unlikeMessage(String likeKey, String userId) {
+	public void unlikeMessage(String likeKey, String userId, Long sessionId, String messageId) {
 		redisTemplate.opsForSet().remove(likeKey, userId);
+
+		// ZSet에서 좋아요 score -1
+		String zsetKey = "questions:session:" + sessionId;
+		redisTemplate.opsForZSet().incrementScore(zsetKey, messageId, -1);
 	}
 
 	// 좋아요 개수 조회

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -61,6 +61,12 @@ public class ChatService {
 
 		chatRepository.saveMessage(message);
 
+		// 메시지 카테고리가 QUESTION인 경우 ZSet에 등록
+		if (message.getCategory() == ChatCategory.QUESTION) {
+			String zsetKey = "questions:session:" + sessionId;
+			redisTemplate.opsForZSet().add(zsetKey, message.getMessageId(), 0); // 초기 좋아요 수 0
+		}
+
 		String jsonMessage = objectMapper.writeValueAsString(message);
 		String redisKey = "chat-" + sessionId;
 

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -11,13 +11,12 @@ import eightplusone.bit.fit.domain.user.repository.UserRedisRepository;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.global.exception.CustomException;
 import eightplusone.bit.fit.global.exception.ErrorCode;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -122,7 +121,7 @@ public class ChatService {
 		if (!chatLikeRepository.hasLiked(likeKey, userId)) {
 			throw new CustomException(ErrorCode.CANNOT_UNLIKE);
 		}
-		chatLikeRepository.unlikeMessage(likeKey, userId);
+		chatLikeRepository.unlikeMessage(likeKey, userId, sessionId, messageId);
 	}
 
 	// 좋아요 개수 조회
@@ -200,49 +199,90 @@ public class ChatService {
 			.collect(Collectors.toList());
 	}
 
-	public Page<ChatMessageDto> getAllQuestionMessages(Long sessionId, Pageable pageable) {
-		if (!chatRepository.existsBySessionId(String.valueOf(sessionId))) {
-			throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
-		}
+	// public Page<ChatMessageDto> getAllQuestionMessages(Long sessionId, Pageable pageable) {
+	// 	if (!chatRepository.existsBySessionId(String.valueOf(sessionId))) {
+	// 		throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
+	// 	}
+	//
+	// 	List<Object> rawMessages = chatRepository.getRecentMessages(String.valueOf(sessionId));
+	//
+	// 	List<ChatMessage> messages = rawMessages.stream()
+	// 		.map(obj -> {
+	// 			if (obj instanceof ChatMessageDto dto) {
+	// 				return new ChatMessage(dto.getMessageId(), sessionId, dto.getUserId(), dto.getCategory(),
+	// 					dto.getMessage(), dto.getTimestamp());
+	// 			} else if (obj instanceof ChatMessage msg) {
+	// 				return msg;
+	// 			}
+	// 			return null;
+	// 		})
+	// 		.filter(Objects::nonNull)
+	// 		.filter(msg -> msg.getCategory() == ChatCategory.QUESTION)
+	// 		.sorted((m1, m2) -> {
+	// 			int likeCount1 = getLikeCount(sessionId, m1.getMessageId());
+	// 			int likeCount2 = getLikeCount(sessionId, m2.getMessageId());
+	// 			return Integer.compare(likeCount2, likeCount1); // 좋아요 내림차순 정렬
+	// 		})
+	// 		.collect(Collectors.toList());
+	//
+	// 	int start = (int)pageable.getOffset();
+	// 	int end = Math.min(start + pageable.getPageSize(), messages.size());
+	//
+	// 	List<ChatMessageDto> pageContent = messages.subList(start, end).stream()
+	// 		.map(msg -> new ChatMessageDto(
+	// 			msg.getMessageId(),
+	// 			msg.getCategory(),
+	// 			msg.getMessage(),
+	// 			userRedisRepository.getUserName(msg.getUserId()),
+	// 			msg.getUserId(),
+	// 			msg.getSessionId(),
+	// 			msg.getTimestamp(),
+	// 			getLikeCount(sessionId, msg.getMessageId())
+	// 		))
+	// 		.collect(Collectors.toList());
+	//
+	// 	return new PageImpl<>(pageContent, pageable, messages.size());
+	// }
 
-		List<Object> rawMessages = chatRepository.getRecentMessages(String.valueOf(sessionId));
+	public List<ChatMessageDto> getZSetSortedQuestions(Long sessionId, int page, int size) {
+		String zsetKey = "questions:session:" + sessionId;
+		int start = page * size;
+		int end = start + size - 1;
 
-		List<ChatMessage> messages = rawMessages.stream()
-			.map(obj -> {
-				if (obj instanceof ChatMessageDto dto) {
-					return new ChatMessage(dto.getMessageId(), sessionId, dto.getUserId(), dto.getCategory(),
-						dto.getMessage(), dto.getTimestamp());
-				} else if (obj instanceof ChatMessage msg) {
-					return msg;
+		Set<Object> messageIds = redisTemplate.opsForZSet().reverseRange(zsetKey, start, end);
+		if (messageIds == null || messageIds.isEmpty())
+			return Collections.emptyList();
+
+		return messageIds.stream()
+			.map(messageIdObj -> {
+				String messageId = messageIdObj.toString();
+				String raw = (String)redisTemplate.opsForValue().get("chat:message:" + messageId);
+				if (raw == null)
+					return null;
+
+				try {
+					ObjectMapper mapper = new ObjectMapper();
+					ChatMessage msg = mapper.readValue(raw, ChatMessage.class);
+					String userName = userRedisRepository.getUserName(msg.getUserId());
+					Double score = redisTemplate.opsForZSet().score(zsetKey, messageId);
+					int likeCount = score != null ? score.intValue() : 0;
+
+					return new ChatMessageDto(
+						msg.getMessageId(),
+						msg.getCategory(),
+						msg.getMessage(),
+						userName != null ? userName : "알 수 없음",
+						msg.getUserId(),
+						msg.getSessionId(),
+						msg.getTimestamp(),
+						likeCount
+					);
+				} catch (JsonProcessingException e) {
+					return null;
 				}
-				return null;
 			})
 			.filter(Objects::nonNull)
-			.filter(msg -> msg.getCategory() == ChatCategory.QUESTION)
-			.sorted((m1, m2) -> {
-				int likeCount1 = getLikeCount(sessionId, m1.getMessageId());
-				int likeCount2 = getLikeCount(sessionId, m2.getMessageId());
-				return Integer.compare(likeCount2, likeCount1); // 좋아요 내림차순 정렬
-			})
-			.collect(Collectors.toList());
-
-		int start = (int)pageable.getOffset();
-		int end = Math.min(start + pageable.getPageSize(), messages.size());
-
-		List<ChatMessageDto> pageContent = messages.subList(start, end).stream()
-			.map(msg -> new ChatMessageDto(
-				msg.getMessageId(),
-				msg.getCategory(),
-				msg.getMessage(),
-				userRedisRepository.getUserName(msg.getUserId()),
-				msg.getUserId(),
-				msg.getSessionId(),
-				msg.getTimestamp(),
-				getLikeCount(sessionId, msg.getMessageId())
-			))
-			.collect(Collectors.toList());
-
-		return new PageImpl<>(pageContent, pageable, messages.size());
+			.toList();
 	}
 
 }

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepositoryTest.java
@@ -11,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 
 @ExtendWith(MockitoExtension.class)
 public class ChatLikeRepositoryTest {
@@ -20,6 +21,9 @@ public class ChatLikeRepositoryTest {
 
 	@Mock
 	private SetOperations<String, Object> setOperations;
+
+	@Mock
+	private ZSetOperations<String, Object> zSetOperations;
 
 	@InjectMocks
 	private ChatLikeRepository chatLikeRepository;
@@ -62,6 +66,8 @@ public class ChatLikeRepositoryTest {
 
 	@Test
 	void shouldRemoveLikeSuccessfully() {
+		when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+
 		String userId = "user1";
 
 		when(setOperations.add(likeKey, userId)).thenReturn(1L);
@@ -73,6 +79,9 @@ public class ChatLikeRepositoryTest {
 
 		int likeCount = chatLikeRepository.getLikeCount(likeKey);
 		assertThat(likeCount).isEqualTo(0);
+
+		// ZSet score 감소 검증
+		verify(zSetOperations).incrementScore("questions:session:" + sessionId, messageId, -1);
 	}
 
 	@Test

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatLikeRepositoryTest.java
@@ -69,7 +69,7 @@ public class ChatLikeRepositoryTest {
 		when(setOperations.size(likeKey)).thenReturn(0L);
 
 		chatLikeRepository.likeMessage(likeKey, userId);
-		chatLikeRepository.unlikeMessage(likeKey, userId);
+		chatLikeRepository.unlikeMessage(likeKey, userId, sessionId, messageId);
 
 		int likeCount = chatLikeRepository.getLikeCount(likeKey);
 		assertThat(likeCount).isEqualTo(0);

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -105,7 +105,7 @@ public class ChatRepositoryTest {
 
 	@Test
 	@Transactional
-		// 🔹 자동 롤백 방지
+		// 자동 롤백 방지
 	void testChatMessageExpiration() throws InterruptedException {
 		// 테스트용 세션 가져오기
 		Session session = sessionRepository.findById(sessionId).orElse(null);

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -13,16 +13,19 @@ import eightplusone.bit.fit.domain.chat.repository.ChatRepository;
 import eightplusone.bit.fit.domain.user.repository.UserRedisRepository;
 import eightplusone.bit.fit.global.exception.CustomException;
 import eightplusone.bit.fit.global.exception.ErrorCode;
+import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
 
 @ExtendWith(MockitoExtension.class)
 class ChatServiceTest {
@@ -262,31 +265,35 @@ class ChatServiceTest {
 	// 	assertThat(page.getTotalElements()).isEqualTo(3); // 전체는 3개
 	// }
 
+	@SuppressWarnings("unchecked")
 	@Test
 	void getZSetSortedQuestions_success() {
 		// given
 		String zsetKey = "questions:session:" + sessionId;
 
-		// ZSet에서 정렬된 메시지 ID 3개 반환한다고 가정
-		when(redisTemplate.opsForZSet().reverseRange(zsetKey, 0, 2))
-			.thenReturn(Set.of("msg3", "msg1", "msg2"));
+		// ZSetOperations mock
+		ZSetOperations<String, Object> zSetOps = Mockito.mock(ZSetOperations.class);
+		Mockito.when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+		Mockito.when(zSetOps.reverseRange(zsetKey, 0, 2))
+			.thenReturn(new LinkedHashSet<>(List.of("msg3", "msg1", "msg2")));
+		Mockito.when(zSetOps.score(zsetKey, "msg3")).thenReturn(10.0);
+		Mockito.when(zSetOps.score(zsetKey, "msg1")).thenReturn(5.0);
+		Mockito.when(zSetOps.score(zsetKey, "msg2")).thenReturn(2.0);
 
-		// 메시지 본문
-		when(redisTemplate.opsForValue().get("chat:message:msg3"))
+		// ValueOperations mock + doReturn().when() 방식
+		ValueOperations<String, String> valueOps = Mockito.mock(ValueOperations.class);
+		Mockito.doReturn(valueOps).when(redisTemplate).opsForValue(); // 핵심 차이점
+		Mockito.when(valueOps.get("chat:message:msg3"))
 			.thenReturn(
 				"{\"messageId\":\"msg3\",\"sessionId\":1,\"userId\":\"user3\",\"category\":\"QUESTION\",\"message\":\"Q3\",\"timestamp\":\"t3\"}");
-		when(redisTemplate.opsForValue().get("chat:message:msg1"))
+		Mockito.when(valueOps.get("chat:message:msg1"))
 			.thenReturn(
 				"{\"messageId\":\"msg1\",\"sessionId\":1,\"userId\":\"user1\",\"category\":\"QUESTION\",\"message\":\"Q1\",\"timestamp\":\"t1\"}");
-		when(redisTemplate.opsForValue().get("chat:message:msg2"))
+		Mockito.when(valueOps.get("chat:message:msg2"))
 			.thenReturn(
 				"{\"messageId\":\"msg2\",\"sessionId\":1,\"userId\":\"user2\",\"category\":\"QUESTION\",\"message\":\"Q2\",\"timestamp\":\"t2\"}");
 
-		// 좋아요 수
-		when(redisTemplate.opsForZSet().score(zsetKey, "msg3")).thenReturn(10.0);
-		when(redisTemplate.opsForZSet().score(zsetKey, "msg1")).thenReturn(5.0);
-		when(redisTemplate.opsForZSet().score(zsetKey, "msg2")).thenReturn(2.0);
-
+		// 사용자 이름
 		when(userRedisRepository.getUserName("user1")).thenReturn("User1");
 		when(userRedisRepository.getUserName("user2")).thenReturn("User2");
 		when(userRedisRepository.getUserName("user3")).thenReturn("User3");

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -14,6 +14,7 @@ import eightplusone.bit.fit.domain.user.repository.UserRedisRepository;
 import eightplusone.bit.fit.global.exception.CustomException;
 import eightplusone.bit.fit.global.exception.ErrorCode;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,9 +22,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 
 @ExtendWith(MockitoExtension.class)
@@ -147,11 +145,11 @@ class ChatServiceTest {
 		String likeKey = "like:" + sessionId + ":" + messageId;
 
 		when(chatLikeRepository.hasLiked(likeKey, userId)).thenReturn(true);
-		doNothing().when(chatLikeRepository).unlikeMessage(likeKey, userId);
+		doNothing().when(chatLikeRepository).unlikeMessage(likeKey, userId, sessionId, messageId);
 
 		chatService.unlikeMessage(userId, sessionId, messageId);
 
-		verify(chatLikeRepository, times(1)).unlikeMessage(likeKey, userId);
+		verify(chatLikeRepository, times(1)).unlikeMessage(likeKey, userId, sessionId, messageId);
 	}
 
 	// 좋아요를 누르지 않은 상태에서 취소하려고 하면 예외가 발생하는지 확인
@@ -230,37 +228,77 @@ class ChatServiceTest {
 		assertThat(top3.get(2).getMessageId()).isEqualTo("msg1"); // 3
 	}
 
+	// @Test
+	// void getAllQuestionMessages_success() {
+	// 	// given
+	// 	Long sessionId = 1L;
+	//
+	// 	ChatMessageDto dto1 = new ChatMessageDto("msg1", ChatCategory.QUESTION, "Q1", "User1", "user1", sessionId, "t1",
+	// 		0);
+	// 	ChatMessageDto dto2 = new ChatMessageDto("msg2", ChatCategory.QUESTION, "Q2", "User2", "user2", sessionId, "t2",
+	// 		0);
+	// 	ChatMessageDto dto3 = new ChatMessageDto("msg3", ChatCategory.QUESTION, "Q3", "User3", "user3", sessionId, "t3",
+	// 		0);
+	//
+	// 	when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
+	// 	when(chatRepository.getRecentMessages(String.valueOf(sessionId))).thenReturn(List.of(dto1, dto2, dto3));
+	//
+	// 	when(userRedisRepository.getUserName("user1")).thenReturn("User1");
+	// 	when(userRedisRepository.getUserName("user3")).thenReturn("User3");
+	//
+	// 	when(chatLikeRepository.getLikeCount("like:1:msg1")).thenReturn(5);
+	// 	when(chatLikeRepository.getLikeCount("like:1:msg2")).thenReturn(2);
+	// 	when(chatLikeRepository.getLikeCount("like:1:msg3")).thenReturn(10);
+	//
+	// 	Pageable pageable = PageRequest.of(0, 2);
+	//
+	// 	// when
+	// 	Page<ChatMessageDto> page = chatService.getAllQuestionMessages(sessionId, pageable);
+	//
+	// 	// then
+	// 	assertThat(page.getContent()).hasSize(2);
+	// 	assertThat(page.getContent().get(0).getMessageId()).isEqualTo("msg3"); // 좋아요 10
+	// 	assertThat(page.getContent().get(1).getMessageId()).isEqualTo("msg1"); // 좋아요 5
+	// 	assertThat(page.getTotalElements()).isEqualTo(3); // 전체는 3개
+	// }
+
 	@Test
-	void getAllQuestionMessages_success() {
+	void getZSetSortedQuestions_success() {
 		// given
-		Long sessionId = 1L;
+		String zsetKey = "questions:session:" + sessionId;
 
-		ChatMessageDto dto1 = new ChatMessageDto("msg1", ChatCategory.QUESTION, "Q1", "User1", "user1", sessionId, "t1",
-			0);
-		ChatMessageDto dto2 = new ChatMessageDto("msg2", ChatCategory.QUESTION, "Q2", "User2", "user2", sessionId, "t2",
-			0);
-		ChatMessageDto dto3 = new ChatMessageDto("msg3", ChatCategory.QUESTION, "Q3", "User3", "user3", sessionId, "t3",
-			0);
+		// ZSet에서 정렬된 메시지 ID 3개 반환한다고 가정
+		when(redisTemplate.opsForZSet().reverseRange(zsetKey, 0, 2))
+			.thenReturn(Set.of("msg3", "msg1", "msg2"));
 
-		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
-		when(chatRepository.getRecentMessages(String.valueOf(sessionId))).thenReturn(List.of(dto1, dto2, dto3));
+		// 메시지 본문
+		when(redisTemplate.opsForValue().get("chat:message:msg3"))
+			.thenReturn(
+				"{\"messageId\":\"msg3\",\"sessionId\":1,\"userId\":\"user3\",\"category\":\"QUESTION\",\"message\":\"Q3\",\"timestamp\":\"t3\"}");
+		when(redisTemplate.opsForValue().get("chat:message:msg1"))
+			.thenReturn(
+				"{\"messageId\":\"msg1\",\"sessionId\":1,\"userId\":\"user1\",\"category\":\"QUESTION\",\"message\":\"Q1\",\"timestamp\":\"t1\"}");
+		when(redisTemplate.opsForValue().get("chat:message:msg2"))
+			.thenReturn(
+				"{\"messageId\":\"msg2\",\"sessionId\":1,\"userId\":\"user2\",\"category\":\"QUESTION\",\"message\":\"Q2\",\"timestamp\":\"t2\"}");
+
+		// 좋아요 수
+		when(redisTemplate.opsForZSet().score(zsetKey, "msg3")).thenReturn(10.0);
+		when(redisTemplate.opsForZSet().score(zsetKey, "msg1")).thenReturn(5.0);
+		when(redisTemplate.opsForZSet().score(zsetKey, "msg2")).thenReturn(2.0);
 
 		when(userRedisRepository.getUserName("user1")).thenReturn("User1");
+		when(userRedisRepository.getUserName("user2")).thenReturn("User2");
 		when(userRedisRepository.getUserName("user3")).thenReturn("User3");
 
-		when(chatLikeRepository.getLikeCount("like:1:msg1")).thenReturn(5);
-		when(chatLikeRepository.getLikeCount("like:1:msg2")).thenReturn(2);
-		when(chatLikeRepository.getLikeCount("like:1:msg3")).thenReturn(10);
-
-		Pageable pageable = PageRequest.of(0, 2);
-
 		// when
-		Page<ChatMessageDto> page = chatService.getAllQuestionMessages(sessionId, pageable);
+		List<ChatMessageDto> result = chatService.getZSetSortedQuestions(sessionId, 0, 3);
 
 		// then
-		assertThat(page.getContent()).hasSize(2);
-		assertThat(page.getContent().get(0).getMessageId()).isEqualTo("msg3"); // 좋아요 10
-		assertThat(page.getContent().get(1).getMessageId()).isEqualTo("msg1"); // 좋아요 5
-		assertThat(page.getTotalElements()).isEqualTo(3); // 전체는 3개
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getMessageId()).isEqualTo("msg3");
+		assertThat(result.get(1).getMessageId()).isEqualTo("msg1");
+		assertThat(result.get(2).getMessageId()).isEqualTo("msg2");
 	}
+
 }

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -231,40 +231,6 @@ class ChatServiceTest {
 		assertThat(top3.get(2).getMessageId()).isEqualTo("msg1"); // 3
 	}
 
-	// @Test
-	// void getAllQuestionMessages_success() {
-	// 	// given
-	// 	Long sessionId = 1L;
-	//
-	// 	ChatMessageDto dto1 = new ChatMessageDto("msg1", ChatCategory.QUESTION, "Q1", "User1", "user1", sessionId, "t1",
-	// 		0);
-	// 	ChatMessageDto dto2 = new ChatMessageDto("msg2", ChatCategory.QUESTION, "Q2", "User2", "user2", sessionId, "t2",
-	// 		0);
-	// 	ChatMessageDto dto3 = new ChatMessageDto("msg3", ChatCategory.QUESTION, "Q3", "User3", "user3", sessionId, "t3",
-	// 		0);
-	//
-	// 	when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
-	// 	when(chatRepository.getRecentMessages(String.valueOf(sessionId))).thenReturn(List.of(dto1, dto2, dto3));
-	//
-	// 	when(userRedisRepository.getUserName("user1")).thenReturn("User1");
-	// 	when(userRedisRepository.getUserName("user3")).thenReturn("User3");
-	//
-	// 	when(chatLikeRepository.getLikeCount("like:1:msg1")).thenReturn(5);
-	// 	when(chatLikeRepository.getLikeCount("like:1:msg2")).thenReturn(2);
-	// 	when(chatLikeRepository.getLikeCount("like:1:msg3")).thenReturn(10);
-	//
-	// 	Pageable pageable = PageRequest.of(0, 2);
-	//
-	// 	// when
-	// 	Page<ChatMessageDto> page = chatService.getAllQuestionMessages(sessionId, pageable);
-	//
-	// 	// then
-	// 	assertThat(page.getContent()).hasSize(2);
-	// 	assertThat(page.getContent().get(0).getMessageId()).isEqualTo("msg3"); // 좋아요 10
-	// 	assertThat(page.getContent().get(1).getMessageId()).isEqualTo("msg1"); // 좋아요 5
-	// 	assertThat(page.getTotalElements()).isEqualTo(3); // 전체는 3개
-	// }
-
 	@SuppressWarnings("unchecked")
 	@Test
 	void getZSetSortedQuestions_success() {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#85 ]

### 로컬 병합
X

### 변경 사항
1. 실시간 좋아요 수에 따른 실시간 질문 정렬이 가능하도록  List -> ZSet 구조로 변경
2. 이에따른 테스트 코드 수정

### 테스트 결과
![스크린샷 2025-03-25 오후 5 24 58](https://github.com/user-attachments/assets/193c666b-01f9-4499-bcf5-c1f37bdaee8c)
![스크린샷 2025-03-25 오후 5 35 36](https://github.com/user-attachments/assets/84630dc6-b4f0-4f5d-9d6b-bb503dc48ae6)
![스크린샷 2025-03-26 오후 1 45 19](https://github.com/user-attachments/assets/a21e9e99-d65f-4e28-ab65-2daac2966fc9)
