### PR TITLE
[#42] 파일크기 제한 및 이미지 유효성 검증

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/image/service/ImageService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/image/service/ImageService.java
@@ -34,7 +34,7 @@ public class ImageService {
 
 	public S3ImageDto uploadToS3(MultipartFile multipartFile) {
 		try (InputStream inputStream = multipartFile.getInputStream()) {
-			validateImageContentType(multipartFile.getContentType());
+			validateImage(multipartFile);
 
 			String imageName = generateUniqueImageName(multipartFile.getOriginalFilename());
 			ObjectMetadata objectMetadata = ObjectMetadata.builder()
@@ -59,8 +59,13 @@ public class ImageService {
 		s3Operations.deleteObject(bucket, imageName);
 	}
 
-	public void validateImageContentType(String contentType) {
+	private void validateImage(MultipartFile multipartFile) {
+		String contentType = multipartFile.getContentType();
+		String name = multipartFile.getOriginalFilename();
 		if (contentType == null || !contentType.startsWith("image/")) {
+			throw new CustomException(ErrorCode.INVALID_REQUEST);
+		}
+		if (name == null || !name.matches(".*\\.(jpg|jpeg|png|webp)$")) {
 			throw new CustomException(ErrorCode.INVALID_REQUEST);
 		}
 	}

--- a/src/main/java/eightplusone/bit/fit/domain/image/service/ImageService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/image/service/ImageService.java
@@ -34,6 +34,7 @@ public class ImageService {
 
 	public S3ImageDto uploadToS3(MultipartFile multipartFile) {
 		try (InputStream inputStream = multipartFile.getInputStream()) {
+			validateImageContentType(multipartFile.getContentType());
 
 			String imageName = generateUniqueImageName(multipartFile.getOriginalFilename());
 			ObjectMetadata objectMetadata = ObjectMetadata.builder()
@@ -56,5 +57,11 @@ public class ImageService {
 	public void deleteFromS3(String url) {
 		String imageName = url.substring(url.lastIndexOf("/") + 1);
 		s3Operations.deleteObject(bucket, imageName);
+	}
+
+	public void validateImageContentType(String contentType) {
+		if (contentType == null || !contentType.startsWith("image/")) {
+			throw new CustomException(ErrorCode.INVALID_REQUEST);
+		}
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/eightplusone/bit/fit/global/exception/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import eightplusone.bit.fit.global.dto.ResponseDto;
 
@@ -28,5 +29,11 @@ public class CustomExceptionHandler {
 			.get(e.getBindingResult().getFieldErrors().size() - 1);
 		String message = fieldError.getField() + " 필드의 입력값[ " + fieldError.getRejectedValue() + " ]이 유효하지 않습니다.";
 		return ResponseEntity.status(BAD_REQUEST).body(ResponseDto.fail(HttpStatus.BAD_REQUEST, message));
+	}
+
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public ResponseEntity<ResponseDto<Object>> handleMaxSizeException(MaxUploadSizeExceededException e) {
+		return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED)
+			.body(ResponseDto.fail(EXPECTATION_FAILED, "해당 파일 크기가 너무 큽니다."));
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#42]

### 변경 사항
- 이미지파일 크기를 10MB를 제한 했습니다 (*YML에서 변경 가능)
- 브라우저가 삽입한 MIME를 검증합니다.
- 파일 확장자를 확인합니다.

### 테스트 결과
![이미지 크기 변경](https://github.com/user-attachments/assets/65938a3c-f6d3-416b-a3a6-06a29d5af99f)
이미지 크기가 10MB를 넘는다면 417에러를 반환합니다.

![확장자 검증을 잠시 지우고 한거MIME다르면 ㄴㄴ](https://github.com/user-attachments/assets/3a7da2b7-77c1-41f4-bfd7-6b05717b307c)
MIME가 다르면 에러를 반환합니다. (정확한 확인을 위해 확장자 검증 없이 진행)

![정상작동](https://github.com/user-attachments/assets/1134607c-9490-4466-a4de-cb738f93a598)
이미지 업로드 시 정상 작동

![SVG제외](https://github.com/user-attachments/assets/d5188ee9-786e-449f-979f-0f87c39de4b3)
보안 이슈로 SVG는 제외 [Kisa 가이드](https://krcert.or.kr/kr/bbs/view.do?bbsId=B0000127&nttId=24807&menuNo=205021)



