### PR TITLE
[#97] 나의 세션 조회 시 강연자 정보 추가

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionScheduleResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionScheduleResponseDto.java
@@ -2,7 +2,7 @@ package eightplusone.bit.fit.domain.mysession.dto;
 
 import java.time.format.DateTimeFormatter;
 
-import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,10 +28,15 @@ public class MySessionScheduleResponseDto {
 	private final Integer audioChannel;
 	@Schema(description = "담은 스케줄인지 여부", example = "true")
 	private final Boolean isMySchedule;
+	@Schema(description = "강연자 이름", example = "홍길동")
+	private final String speakerName;
+	@Schema(description = "강연자 이미지", example = "http://localhost:8080/speaker.png")
+	private final String speakerImage;
 
 	@Builder
 	private MySessionScheduleResponseDto(Long sessionId, String title, String sessionImage, String summary,
-		String startTime, String endTime, Integer standardCount, Integer audioChannel, Boolean isMySchedule) {
+		String startTime, String endTime, Integer standardCount, Integer audioChannel, Boolean isMySchedule,
+		String speakerName, String speakerImage) {
 		this.sessionId = sessionId;
 		this.title = title;
 		this.sessionImage = sessionImage;
@@ -41,20 +46,24 @@ public class MySessionScheduleResponseDto {
 		this.standardCount = standardCount;
 		this.audioChannel = audioChannel;
 		this.isMySchedule = isMySchedule;
+		this.speakerName = speakerName;
+		this.speakerImage = speakerImage;
 	}
 
-	public static MySessionScheduleResponseDto from(Session session, Boolean isMySchedule) {
+	public static MySessionScheduleResponseDto from(Speaker speaker, Boolean isMySchedule) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
 		return MySessionScheduleResponseDto.builder()
-			.sessionId(session.getSessionId())
-			.title(session.getTitle())
-			.sessionImage(session.getSessionImage())
-			.summary(session.getSummary())
-			.startTime(session.getStartTime().format(formatter))
-			.endTime(session.getEndTime().format(formatter))
-			.standardCount(session.getStandardCount())
-			.audioChannel(session.getAudioChannel())
+			.sessionId(speaker.getSession().getSessionId())
+			.title(speaker.getSession().getTitle())
+			.sessionImage(speaker.getSession().getSessionImage())
+			.summary(speaker.getSession().getSummary())
+			.startTime(speaker.getSession().getStartTime().format(formatter))
+			.endTime(speaker.getSession().getEndTime().format(formatter))
+			.standardCount(speaker.getSession().getStandardCount())
+			.audioChannel(speaker.getSession().getAudioChannel())
 			.isMySchedule(isMySchedule)
+			.speakerName(speaker.getName())
+			.speakerImage(speaker.getImage())
 			.build();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
@@ -13,6 +13,8 @@ import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
 import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.global.exception.CustomException;
@@ -27,6 +29,7 @@ public class MySessionService {
 	private final MySessionRepository mySessionRepository;
 	private final UserRepository userRepository;
 	private final SessionRepository sessionRepository;
+	private final SpeakerRepository speakerRepository;
 
 	@Transactional
 	public void registerMySession(String email, Long sessionId) {
@@ -46,11 +49,12 @@ public class MySessionService {
 			.map(mySession -> mySession.getSession().getSessionId())
 			.toList();
 
-		// 전체세션조회
-		List<Session> allSessions = sessionRepository.findAll();
+		// 전체세션 및 강연자 조회
+		List<Speaker> allSpeakersWithSession = speakerRepository.findAllWithSession();
 
-		return allSessions.stream()
-			.map(session -> MySessionScheduleResponseDto.from(session, mySessionIds.contains(session.getSessionId())))
+		return allSpeakersWithSession.stream()
+			.map(speaker -> MySessionScheduleResponseDto.from(speaker,
+				mySessionIds.contains(speaker.getSession().getSessionId())))
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/speaker/repository/SpeakerRepository.java
@@ -1,8 +1,13 @@
 package eightplusone.bit.fit.domain.speaker.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 
 public interface SpeakerRepository extends JpaRepository<Speaker, Long> {
+	@Query("select sp from Speaker sp join fetch sp.session")
+	List<Speaker> findAllWithSession();
 }

--- a/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
@@ -20,9 +20,12 @@ import eightplusone.bit.fit.domain.mysession.enums.MySessionType;
 import eightplusone.bit.fit.domain.mysession.repository.MySessionRepository;
 import eightplusone.bit.fit.domain.session.entity.Session;
 import eightplusone.bit.fit.domain.session.repository.SessionRepository;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
+import eightplusone.bit.fit.domain.speaker.repository.SpeakerRepository;
 import eightplusone.bit.fit.domain.user.entity.User;
 import eightplusone.bit.fit.domain.user.repository.UserRepository;
 import eightplusone.bit.fit.support.fixture.SessionFixture;
+import eightplusone.bit.fit.support.fixture.SpeakerFixture;
 import eightplusone.bit.fit.support.fixture.UserFixture;
 
 @SpringBootTest
@@ -37,10 +40,13 @@ class MySessionServiceTest {
 	SessionRepository sessionRepository;
 	@Autowired
 	MySessionRepository mySessionRepository;
+	@Autowired
+	SpeakerRepository speakerRepository;
 
 	@BeforeEach
 	void cleanUp() {
 		mySessionRepository.deleteAllInBatch();
+		speakerRepository.deleteAllInBatch();
 		sessionRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 	}
@@ -79,13 +85,23 @@ class MySessionServiceTest {
 		//given
 		User user = userRepository.save(UserFixture.USER_FIXTURE_1.createUser());
 
-		Session session1 = sessionRepository.save(SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession());
-		Session session2 = sessionRepository.save(SessionFixture.SESSION_STAGE_2_FIXTURE_2.createSession());
-		Session session3 = sessionRepository.save(SessionFixture.SESSION_STAGE_3_FIXTURE_3.createSession());
-		Session session4 = sessionRepository.save(SessionFixture.SESSION_STAGE_4_FIXTURE_1.createSession());
+		Speaker speakerFixture1 = SpeakerFixture.SPEAKER_FIXTURE_1.createSpeaker();
+		Speaker speakerFixture2 = SpeakerFixture.SPEAKER_FIXTURE_2.createSpeaker();
+		Speaker speakerFixture3 = SpeakerFixture.SPEAKER_FIXTURE_3.createSpeaker();
+		Speaker speakerFixture4 = SpeakerFixture.SPEAKER_FIXTURE_4.createSpeaker();
 
-		mySessionRepository.save(MySession.register(user, session1));
-		mySessionRepository.save(MySession.register(user, session2));
+		sessionRepository.save(speakerFixture1.getSession());
+		sessionRepository.save(speakerFixture2.getSession());
+		sessionRepository.save(speakerFixture3.getSession());
+		sessionRepository.save(speakerFixture4.getSession());
+
+		Speaker speaker1 = speakerRepository.save(speakerFixture1);
+		Speaker speaker2 = speakerRepository.save(speakerFixture2);
+		Speaker speaker3 = speakerRepository.save(speakerFixture3);
+		Speaker speaker4 = speakerRepository.save(speakerFixture4);
+
+		mySessionRepository.save(MySession.register(user, speaker1.getSession()));
+		mySessionRepository.save(MySession.register(user, speaker2.getSession()));
 
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
 
@@ -95,52 +111,56 @@ class MySessionServiceTest {
 
 		//then
 		assertAll(
-			() -> assertThat(responseDtos.get(0).getSessionId()).isEqualTo(session1.getSessionId()),
-			() -> assertThat(responseDtos.get(0).getTitle()).isEqualTo(session1.getTitle()),
-			() -> assertThat(responseDtos.get(0).getSummary()).isEqualTo(session1.getSummary()),
-			() -> assertThat(responseDtos.get(0).getSessionImage()).isEqualTo(session1.getSessionImage()),
-			() -> assertThat(responseDtos.get(0).getStandardCount()).isEqualTo(session1.getStandardCount()),
-			() -> assertThat(responseDtos.get(0).getAudioChannel()).isEqualTo(session1.getAudioChannel()),
+			() -> assertThat(responseDtos.get(0).getSessionId()).isEqualTo(speaker1.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(0).getTitle()).isEqualTo(speaker1.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(0).getSummary()).isEqualTo(speaker1.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(0).getSessionImage()).isEqualTo(speaker1.getSession().getSessionImage()),
+			() -> assertThat(responseDtos.get(0).getStandardCount()).isEqualTo(
+				speaker1.getSession().getStandardCount()),
+			() -> assertThat(responseDtos.get(0).getAudioChannel()).isEqualTo(speaker1.getSession().getAudioChannel()),
 			() -> assertThat(responseDtos.get(0).getStartTime()).isEqualTo(
-				session1.getStartTime().format(formatter)),
+				speaker1.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(0).getEndTime()).isEqualTo(
-				session1.getEndTime().format(formatter)),
+				speaker1.getSession().getEndTime().format(formatter)),
 			() -> assertThat(responseDtos.get(0).getIsMySchedule()).isTrue(),
 
-			() -> assertThat(responseDtos.get(1).getSessionId()).isEqualTo(session2.getSessionId()),
-			() -> assertThat(responseDtos.get(1).getTitle()).isEqualTo(session2.getTitle()),
-			() -> assertThat(responseDtos.get(1).getSummary()).isEqualTo(session2.getSummary()),
-			() -> assertThat(responseDtos.get(1).getSessionImage()).isEqualTo(session2.getSessionImage()),
-			() -> assertThat(responseDtos.get(1).getStandardCount()).isEqualTo(session2.getStandardCount()),
-			() -> assertThat(responseDtos.get(1).getAudioChannel()).isEqualTo(session2.getAudioChannel()),
+			() -> assertThat(responseDtos.get(1).getSessionId()).isEqualTo(speaker2.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(1).getTitle()).isEqualTo(speaker2.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(1).getSummary()).isEqualTo(speaker2.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(1).getSessionImage()).isEqualTo(speaker2.getSession().getSessionImage()),
+			() -> assertThat(responseDtos.get(1).getStandardCount()).isEqualTo(
+				speaker2.getSession().getStandardCount()),
+			() -> assertThat(responseDtos.get(1).getAudioChannel()).isEqualTo(speaker2.getSession().getAudioChannel()),
 			() -> assertThat(responseDtos.get(1).getStartTime()).isEqualTo(
-				session2.getStartTime().format(formatter)),
+				speaker2.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(1).getEndTime()).isEqualTo(
-				session2.getEndTime().format(formatter)),
+				speaker2.getSession().getEndTime().format(formatter)),
 			() -> assertThat(responseDtos.get(1).getIsMySchedule()).isTrue(),
 
-			() -> assertThat(responseDtos.get(2).getSessionId()).isEqualTo(session3.getSessionId()),
-			() -> assertThat(responseDtos.get(2).getTitle()).isEqualTo(session3.getTitle()),
-			() -> assertThat(responseDtos.get(2).getSummary()).isEqualTo(session3.getSummary()),
-			() -> assertThat(responseDtos.get(2).getSessionImage()).isEqualTo(session3.getSessionImage()),
-			() -> assertThat(responseDtos.get(2).getStandardCount()).isEqualTo(session3.getStandardCount()),
-			() -> assertThat(responseDtos.get(2).getAudioChannel()).isEqualTo(session3.getAudioChannel()),
+			() -> assertThat(responseDtos.get(2).getSessionId()).isEqualTo(speaker3.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(2).getTitle()).isEqualTo(speaker3.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(2).getSummary()).isEqualTo(speaker3.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(2).getSessionImage()).isEqualTo(speaker3.getSession().getSessionImage()),
+			() -> assertThat(responseDtos.get(2).getStandardCount()).isEqualTo(
+				speaker3.getSession().getStandardCount()),
+			() -> assertThat(responseDtos.get(2).getAudioChannel()).isEqualTo(speaker3.getSession().getAudioChannel()),
 			() -> assertThat(responseDtos.get(2).getStartTime()).isEqualTo(
-				session3.getStartTime().format(formatter)),
+				speaker3.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(2).getEndTime()).isEqualTo(
-				session3.getEndTime().format(formatter)),
+				speaker3.getSession().getEndTime().format(formatter)),
 			() -> assertThat(responseDtos.get(2).getIsMySchedule()).isFalse(),
 
-			() -> assertThat(responseDtos.get(3).getSessionId()).isEqualTo(session4.getSessionId()),
-			() -> assertThat(responseDtos.get(3).getTitle()).isEqualTo(session4.getTitle()),
-			() -> assertThat(responseDtos.get(3).getSummary()).isEqualTo(session4.getSummary()),
-			() -> assertThat(responseDtos.get(3).getSessionImage()).isEqualTo(session4.getSessionImage()),
-			() -> assertThat(responseDtos.get(3).getStandardCount()).isEqualTo(session4.getStandardCount()),
-			() -> assertThat(responseDtos.get(3).getAudioChannel()).isEqualTo(session4.getAudioChannel()),
+			() -> assertThat(responseDtos.get(3).getSessionId()).isEqualTo(speaker4.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(3).getTitle()).isEqualTo(speaker4.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(3).getSummary()).isEqualTo(speaker4.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(3).getSessionImage()).isEqualTo(speaker4.getSession().getSessionImage()),
+			() -> assertThat(responseDtos.get(3).getStandardCount()).isEqualTo(
+				speaker4.getSession().getStandardCount()),
+			() -> assertThat(responseDtos.get(3).getAudioChannel()).isEqualTo(speaker4.getSession().getAudioChannel()),
 			() -> assertThat(responseDtos.get(3).getStartTime()).isEqualTo(
-				session4.getStartTime().format(formatter)),
+				speaker4.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(3).getEndTime()).isEqualTo(
-				session4.getEndTime().format(formatter)),
+				speaker4.getSession().getEndTime().format(formatter)),
 			() -> assertThat(responseDtos.get(3).getIsMySchedule()).isFalse()
 		);
 	}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#97]

### 변경 사항
sessions/all에 시간이 필요하다고 요청을 받았지만,
sessions/all는 페이지네이션으로 메인페이지에서 사용될 것으로 확인되었습니다.

users/session에서 작업하는게 맞다고 생각했습니다.
수정 요청 받은 세션 시간이랑 관계없이, 미리담기에 전체 조회에 강연자 정보가 있어야하는게 맞다고 판단했습니다.

따라서 강연자 정보를 나의 미리담기 스케쥴에 추가 했습니다.

스피커가 세션을 참조하는 단방향 연관관계로 매핑이 되어있어서 SpeakerRepository를 이용하였습니다 !

### 테스트 결과
[API 테스트]
<img width="1437" alt="스크린샷 2025-03-27 오후 10 39 35" src="https://github.com/user-attachments/assets/73ced270-1f81-42f5-b524-a9669081cd32" />
강연자 이름과 이미지가 추가 되었습니다.

[Service 테스트]
<img width="433" alt="스크린샷 2025-03-27 오후 11 08 00" src="https://github.com/user-attachments/assets/4463bc57-0d20-4fee-93d1-2a6ed177cf1b" />
