### PR TITLE
[#104] 채팅방 생성 api

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -38,6 +38,15 @@ public class ChatController {
 		this.userRepository = userRepository;
 	}
 
+	@Operation(summary = "채팅방 생성", description = "채팅 세션이 없으면 새로 생성하고, 있으면 그대로 사용합니다.")
+	@PostMapping("/session/{sessionId}")
+	public ResponseEntity<String> createChatSession(
+		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable Long sessionId
+	) {
+		chatService.createChatSession(sessionId);
+		return ResponseEntity.ok("채팅방 생성 완료 또는 이미 존재: " + sessionId);
+	}
+
 	@Operation(summary = "메시지 전송", description = "특정 채팅 세션에 메시지를 전송합니다.")
 	@MessageMapping("/chat/{sessionId}")
 	public void sendMessage(

--- a/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/repository/ChatRepository.java
@@ -24,6 +24,10 @@ public class ChatRepository {
 		this.sessionRepository = sessionRepository;
 	}
 
+	public void createChatSession(String sessionId) {
+		redisTemplate.opsForValue().set("chat-" + sessionId, "active");
+	}
+
 	// 채팅 메시지 저장
 	public void saveMessage(ChatMessage message) {
 		String chatKey = CHAT_LIST_KEY + message.getSessionId();

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -38,6 +38,16 @@ public class ChatService {
 		this.userRepository = userRepository;
 	}
 
+	public void createChatSession(Long sessionId) {
+		if (chatRepository.existsBySessionId(String.valueOf(sessionId))) {
+			log.info("이미 존재하는 채팅방: {}", sessionId);
+			return;
+		}
+
+		chatRepository.createChatSession(String.valueOf(sessionId));
+		log.info("새 채팅방 생성됨: {}", sessionId);
+	}
+
 	public void sendMessageWithEmail(ChatMessageDto dto, String email, Long sessionId) throws JsonProcessingException {
 		if (dto.getMessage() == null || dto.getMessage().trim().isEmpty()) {
 			throw new CustomException(ErrorCode.INVALID_MESSAGE_FORMAT);

--- a/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/repository/ChatRepositoryTest.java
@@ -174,4 +174,13 @@ public class ChatRepositoryTest {
 		});
 	}
 
+	@Test
+	void testCreateChatSession() {
+		// given
+		Long newSessionId = 9999L;
+		chatRepository.createChatSession(String.valueOf(newSessionId));
+		// then
+		assertTrue(chatRepository.existsBySessionId(String.valueOf(newSessionId)), "채팅방 생성 후 존재하지 않음!");
+	}
+
 }

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -82,6 +82,33 @@ class ChatServiceTest {
 			.build();
 	}
 
+	@Test
+	void createChatSession_shouldCreateIfNotExists() {
+		// given
+		Long testSessionId = 99L;
+		when(chatRepository.existsBySessionId(String.valueOf(testSessionId))).thenReturn(false);
+		doNothing().when(chatRepository).createChatSession(String.valueOf(testSessionId));
+
+		// when
+		chatService.createChatSession(testSessionId);
+
+		// then
+		verify(chatRepository, times(1)).createChatSession(String.valueOf(testSessionId));
+	}
+
+	@Test
+	void createChatSession_shouldNotCreateIfAlreadyExists() {
+		// given
+		Long testSessionId = 100L;
+		when(chatRepository.existsBySessionId(String.valueOf(testSessionId))).thenReturn(true);
+
+		// when
+		chatService.createChatSession(testSessionId);
+
+		// then
+		verify(chatRepository, never()).createChatSession(any());
+	}
+
 	// 채팅 메시지를 성공적으로 저장하고 레디스에 발행되는지 확인
 	@Test
 	void sendMessage_success() throws JsonProcessingException {


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [X] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [X] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#104 ]

### 로컬 병합
X

### 변경 사항
`eightplusone.bit.fit.global.exception.CustomException: 해당 세션의 채팅을 찾을 수 없습니다.`
프론트 측에서 해당 오류가 떠, 채팅방 생성이 먼저 필요하다는 판단하에 채팅방 생성 api를 추가하였습니다.

### 테스트 결과
![image](https://github.com/user-attachments/assets/2447e6b4-5bf6-439f-b48f-1319523811ea)
![image](https://github.com/user-attachments/assets/3fc08d17-dbe4-4bdc-a0cf-b1a18d4c9ed6)


