### PR TITLE
[#54]좋아요 세션 조회 리스트에 강연자 정보 추가

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionLikedSessionsResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/dto/MySessionLikedSessionsResponseDto.java
@@ -2,7 +2,7 @@ package eightplusone.bit.fit.domain.mysession.dto;
 
 import java.time.format.DateTimeFormatter;
 
-import eightplusone.bit.fit.domain.session.entity.Session;
+import eightplusone.bit.fit.domain.speaker.entity.Speaker;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,25 +20,33 @@ public class MySessionLikedSessionsResponseDto {
 	private final String startTime;
 	@Schema(description = "강연 종료 시간", example = "202504021050")
 	private final String endTime;
+	@Schema(description = "강연자 이름", example = "홍길동")
+	private final String speakerName;
+	@Schema(description = "강연자 이미지", example = "http://localhost:8080/speaker.png")
+	private final String speakerImage;
 
 	@Builder
 	private MySessionLikedSessionsResponseDto(Long sessionId, String title, String summary, String startTime,
-		String endTime) {
+		String endTime, String speakerName, String speakerImage) {
 		this.sessionId = sessionId;
 		this.title = title;
 		this.summary = summary;
 		this.startTime = startTime;
 		this.endTime = endTime;
+		this.speakerName = speakerName;
+		this.speakerImage = speakerImage;
 	}
 
-	public static MySessionLikedSessionsResponseDto from(Session session) {
+	public static MySessionLikedSessionsResponseDto from(Speaker speaker) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
 		return MySessionLikedSessionsResponseDto.builder()
-			.sessionId(session.getSessionId())
-			.title(session.getTitle())
-			.summary(session.getSummary())
-			.startTime(session.getStartTime().format(formatter))
-			.endTime(session.getEndTime().format(formatter))
+			.sessionId(speaker.getSession().getSessionId())
+			.title(speaker.getSession().getTitle())
+			.summary(speaker.getSession().getSummary())
+			.startTime(speaker.getSession().getStartTime().format(formatter))
+			.endTime(speaker.getSession().getEndTime().format(formatter))
+			.speakerName(speaker.getName())
+			.speakerImage(speaker.getImage())
 			.build();
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/mysession/service/MySessionService.java
@@ -68,9 +68,18 @@ public class MySessionService {
 
 	public List<MySessionLikedSessionsResponseDto> findLikedMySessions(String email) {
 		User user = userRepository.findLoginUserByEmail(email);
-		return mySessionRepository.findSessionsByUserIdAndType(user.getId(), MySessionType.LIKE)
+
+		List<Long> mySessionIds = mySessionRepository.findSessionsByUserIdAndType(user.getId(),
+				MySessionType.LIKE)
 			.stream()
-			.map(mySession -> MySessionLikedSessionsResponseDto.from(mySession.getSession()))
+			.map(mySession -> mySession.getSession().getSessionId())
+			.toList();
+
+		List<Speaker> allSpeakersWithSession = speakerRepository.findAllWithSession();
+
+		return allSpeakersWithSession.stream()
+			.filter(speaker -> mySessionIds.contains(speaker.getSession().getSessionId()))
+			.map(MySessionLikedSessionsResponseDto::from)
 			.collect(Collectors.toList());
 	}
 

--- a/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/mysession/service/MySessionServiceTest.java
@@ -199,15 +199,23 @@ class MySessionServiceTest {
 		//given
 		User user = userRepository.save(UserFixture.USER_FIXTURE_1.createUser());
 
-		Session session1 = sessionRepository.save(SessionFixture.SESSION_STAGE_1_FIXTURE_1.createSession());
-		Session session2 = sessionRepository.save(SessionFixture.SESSION_STAGE_2_FIXTURE_2.createSession());
-		Session session3 = sessionRepository.save(SessionFixture.SESSION_STAGE_3_FIXTURE_3.createSession());
-		Session session4 = sessionRepository.save(SessionFixture.SESSION_STAGE_4_FIXTURE_1.createSession());
+		Speaker speakerFixture1 = SpeakerFixture.SPEAKER_FIXTURE_1.createSpeaker();
+		Speaker speakerFixture2 = SpeakerFixture.SPEAKER_FIXTURE_2.createSpeaker();
+		Speaker speakerFixture3 = SpeakerFixture.SPEAKER_FIXTURE_3.createSpeaker();
+		Speaker speakerFixture4 = SpeakerFixture.SPEAKER_FIXTURE_4.createSpeaker();
 
-		mySessionRepository.save(MySession.like(user, session1));
-		mySessionRepository.save(MySession.like(user, session2));
-		mySessionRepository.save(MySession.like(user, session3));
-		mySessionRepository.save(MySession.like(user, session4));
+		sessionRepository.save(speakerFixture1.getSession());
+		sessionRepository.save(speakerFixture2.getSession());
+		sessionRepository.save(speakerFixture3.getSession());
+		sessionRepository.save(speakerFixture4.getSession());
+
+		Speaker speaker1 = speakerRepository.save(speakerFixture1);
+		Speaker speaker2 = speakerRepository.save(speakerFixture2);
+		Speaker speaker3 = speakerRepository.save(speakerFixture3);
+		Speaker speaker4 = speakerRepository.save(speakerFixture4);
+
+		mySessionRepository.save(MySession.like(user, speaker1.getSession()));
+		mySessionRepository.save(MySession.like(user, speaker2.getSession()));
 
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMddHHmm");
 
@@ -217,37 +225,25 @@ class MySessionServiceTest {
 
 		//then
 		assertAll(
-			() -> assertThat(responseDtos.get(0).getSessionId()).isEqualTo(session1.getSessionId()),
-			() -> assertThat(responseDtos.get(0).getTitle()).isEqualTo(session1.getTitle()),
-			() -> assertThat(responseDtos.get(0).getSummary()).isEqualTo(session1.getSummary()),
+			() -> assertThat(responseDtos.get(0).getSessionId()).isEqualTo(speaker1.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(0).getTitle()).isEqualTo(speaker1.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(0).getSummary()).isEqualTo(speaker1.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(0).getSpeakerName()).isEqualTo(speaker1.getName()),
+			() -> assertThat(responseDtos.get(0).getSpeakerImage()).isEqualTo(speaker1.getImage()),
 			() -> assertThat(responseDtos.get(0).getStartTime()).isEqualTo(
-				session1.getStartTime().format(formatter)),
+				speaker1.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(0).getEndTime()).isEqualTo(
-				session1.getEndTime().format(formatter)),
+				speaker1.getSession().getEndTime().format(formatter)),
 
-			() -> assertThat(responseDtos.get(1).getSessionId()).isEqualTo(session2.getSessionId()),
-			() -> assertThat(responseDtos.get(1).getTitle()).isEqualTo(session2.getTitle()),
-			() -> assertThat(responseDtos.get(1).getSummary()).isEqualTo(session2.getSummary()),
+			() -> assertThat(responseDtos.get(1).getSessionId()).isEqualTo(speaker2.getSession().getSessionId()),
+			() -> assertThat(responseDtos.get(1).getTitle()).isEqualTo(speaker2.getSession().getTitle()),
+			() -> assertThat(responseDtos.get(1).getSummary()).isEqualTo(speaker2.getSession().getSummary()),
+			() -> assertThat(responseDtos.get(1).getSpeakerName()).isEqualTo(speaker2.getName()),
+			() -> assertThat(responseDtos.get(1).getSpeakerImage()).isEqualTo(speaker2.getImage()),
 			() -> assertThat(responseDtos.get(1).getStartTime()).isEqualTo(
-				session2.getStartTime().format(formatter)),
+				speaker2.getSession().getStartTime().format(formatter)),
 			() -> assertThat(responseDtos.get(1).getEndTime()).isEqualTo(
-				session2.getEndTime().format(formatter)),
-
-			() -> assertThat(responseDtos.get(2).getSessionId()).isEqualTo(session3.getSessionId()),
-			() -> assertThat(responseDtos.get(2).getTitle()).isEqualTo(session3.getTitle()),
-			() -> assertThat(responseDtos.get(2).getSummary()).isEqualTo(session3.getSummary()),
-			() -> assertThat(responseDtos.get(2).getStartTime()).isEqualTo(
-				session3.getStartTime().format(formatter)),
-			() -> assertThat(responseDtos.get(2).getEndTime()).isEqualTo(
-				session3.getEndTime().format(formatter)),
-
-			() -> assertThat(responseDtos.get(3).getSessionId()).isEqualTo(session4.getSessionId()),
-			() -> assertThat(responseDtos.get(3).getTitle()).isEqualTo(session4.getTitle()),
-			() -> assertThat(responseDtos.get(3).getSummary()).isEqualTo(session4.getSummary()),
-			() -> assertThat(responseDtos.get(3).getStartTime()).isEqualTo(
-				session4.getStartTime().format(formatter)),
-			() -> assertThat(responseDtos.get(3).getEndTime()).isEqualTo(
-				session4.getEndTime().format(formatter))
+				speaker2.getSession().getEndTime().format(formatter))
 		);
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#54]

### 변경 사항
- 좋아요 세션 조회 리스트에 강연자 정보 추가

### 테스트 결과
[API 테스트]
![스크린샷 2025-03-29 오전 12 41 13](https://github.com/user-attachments/assets/8b48596f-a565-49f6-915c-d573cae99f7d)

[총 쿼리문]
![스크린샷 2025-03-29 오전 12 40 19](https://github.com/user-attachments/assets/c6b666d6-0af7-4a4c-b01a-5a8a21519d05)

[Service Test]
![스크린샷 2025-03-29 오전 12 51 19](https://github.com/user-attachments/assets/1e180231-3fa5-438b-9004-d353d8823c92)

### 추가 사항

좋아요 담기를 진행한 세션에 강연자 정보를 추가해야되는 상황입니다.

Speaker에 FK가 존재하는 단방향 연관관계가 Session과 이어져있습니다.

따라서, Session에서 MySession과 Speaker를 조인하여 한방 쿼리로 모두 가져올 수 없는 상항입니다.

마감기한을 앞두고 Speaker와 Session에 연관관계 매핑의 변경으로 문제가 생겨 월요일 화요일로 넘어간다면, 오히려 테스트비용을 낭비하는 일이라고 판단했습니다. 

해결방안

저는 저희 서비스에 세션의 개수가 적은 상태라고 생각합니다. (DB에서 불러올 데이터가 적다.)
```java
	public List<MySessionScheduleResponseDto> findRegisteredMySessions(String email) {
		User user = userRepository.findLoginUserByEmail(email);

		// 등록세션 조회
		List<Long> mySessionIds = mySessionRepository.findSessionsByUserIdAndType(user.getId(),
				MySessionType.REGISTER)
			.stream()
			.map(mySession -> mySession.getSession().getSessionId())
			.toList();

		// 전체세션 및 강연자 조회
		List<Speaker> allSpeakersWithSession = speakerRepository.findAllWithSession();

		return allSpeakersWithSession.stream()
			.map(speaker -> MySessionScheduleResponseDto.from(speaker,
				mySessionIds.contains(speaker.getSession().getSessionId())))
			.collect(Collectors.toList());
	}
```

그러므로, 전체세션 조회 + 미리담기를 묶어서 응답하는 findRegisteredMySessions처럼 세션 전체 조회를 응용하여 진행하여도 큰 성능적 문제는 발생하지 않을 것 같다 판단하여 진행 하였습니다.