### PR TITLE
[#110] ChatSubscriber 수정

### DIFF
--- a/src/main/java/eightplusone/bit/fit/global/pubsub/ChatSubscriber.java
+++ b/src/main/java/eightplusone/bit/fit/global/pubsub/ChatSubscriber.java
@@ -1,16 +1,14 @@
 package eightplusone.bit.fit.global.pubsub;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eightplusone.bit.fit.domain.chat.dto.ChatMessageDto;
+import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
 import java.nio.charset.StandardCharsets;
-
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import eightplusone.bit.fit.domain.chat.dto.ChatMessageDto;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
@@ -25,27 +23,38 @@ public class ChatSubscriber implements MessageListener {
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
 		try {
-			// Redis에서 받은 메시지 출력
 			String receivedMessage = new String(message.getBody(), StandardCharsets.UTF_8);
 			String channelName = new String(message.getChannel(), StandardCharsets.UTF_8);
 
 			log.info("Redis에서 메시지 수신: 채널={}, 메시지={}", channelName, receivedMessage);
 
-			// ChatMessageDto로 변환하여 WebSocket으로 전송
-			ChatMessageDto chatMessageDto = objectMapper.readValue(receivedMessage, ChatMessageDto.class);
+			// ChatMessage 기준으로 역직렬화
+			ChatMessage chatMessage = objectMapper.readValue(receivedMessage, ChatMessage.class);
 
-			String sessionId = channelName.replace("chat-", "");
+			// 채널명에서 sessionId 추출 (chat-pub:3 → 3)
+			String sessionId = channelName.replace("chat-pub:", "");
 			String websocketDestination = "/sub/chat/" + sessionId;
 
-			log.info("WebSocket으로 전송 시도: {} -> {}", websocketDestination, chatMessageDto);
+			// 필요한 필드만 넣어서 ChatMessageDto 구성 (name, likes 생략 가능)
+			ChatMessageDto dto = new ChatMessageDto(
+				chatMessage.getMessageId(),
+				chatMessage.getCategory(),
+				chatMessage.getMessage(),
+				null, // name - Redis 캐시에서 조회하거나 null
+				chatMessage.getUserId(),
+				chatMessage.getSessionId(),
+				chatMessage.getTimestamp(),
+				0 // likes - 조회 안 했으면 기본값 0
+			);
 
-			// 메세지 전송
-			messagingTemplate.convertAndSend(websocketDestination, chatMessageDto);
+			log.info("WebSocket으로 전송 시도: {} -> {}", websocketDestination, dto);
+
+			messagingTemplate.convertAndSend(websocketDestination, dto);
 
 			log.info("WebSocket으로 전송 완료: {}", websocketDestination);
 
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.error("Redis 메시지 처리 중 오류", e);
 		}
 	}
 }

--- a/src/main/java/eightplusone/bit/fit/global/pubsub/ChatSubscriber.java
+++ b/src/main/java/eightplusone/bit/fit/global/pubsub/ChatSubscriber.java
@@ -3,10 +3,12 @@ package eightplusone.bit.fit.global.pubsub;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eightplusone.bit.fit.domain.chat.dto.ChatMessageDto;
 import eightplusone.bit.fit.domain.chat.entity.ChatMessage;
+import eightplusone.bit.fit.domain.user.repository.UserRedisRepository;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -15,9 +17,15 @@ import org.springframework.stereotype.Component;
 public class ChatSubscriber implements MessageListener {
 	private final SimpMessagingTemplate messagingTemplate;
 	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final UserRedisRepository userRedisRepository;
 
-	public ChatSubscriber(SimpMessagingTemplate messagingTemplate) {
+	public ChatSubscriber(SimpMessagingTemplate messagingTemplate,
+		RedisTemplate<String, Object> redisTemplate,
+		UserRedisRepository userRedisRepository) {
 		this.messagingTemplate = messagingTemplate;
+		this.redisTemplate = redisTemplate;
+		this.userRedisRepository = userRedisRepository;
 	}
 
 	@Override
@@ -28,31 +36,32 @@ public class ChatSubscriber implements MessageListener {
 
 			log.info("Redis에서 메시지 수신: 채널={}, 메시지={}", channelName, receivedMessage);
 
-			// ChatMessage 기준으로 역직렬화
 			ChatMessage chatMessage = objectMapper.readValue(receivedMessage, ChatMessage.class);
 
-			// 채널명에서 sessionId 추출 (chat-pub:3 → 3)
 			String sessionId = channelName.replace("chat-pub:", "");
 			String websocketDestination = "/sub/chat/" + sessionId;
 
-			// 필요한 필드만 넣어서 ChatMessageDto 구성 (name, likes 생략 가능)
+			// 이름 조회
+			String userName = userRedisRepository.getUserName(chatMessage.getUserId());
+
+			// 좋아요 수 조회
+			String zsetKey = "questions:session:" + sessionId;
+			Double score = redisTemplate.opsForZSet().score(zsetKey, chatMessage.getMessageId());
+			int likeCount = score != null ? score.intValue() : 0;
+
 			ChatMessageDto dto = new ChatMessageDto(
 				chatMessage.getMessageId(),
 				chatMessage.getCategory(),
 				chatMessage.getMessage(),
-				null, // name - Redis 캐시에서 조회하거나 null
+				userName != null ? userName : "알 수 없음",
 				chatMessage.getUserId(),
 				chatMessage.getSessionId(),
 				chatMessage.getTimestamp(),
-				0 // likes - 조회 안 했으면 기본값 0
+				likeCount
 			);
 
 			log.info("WebSocket으로 전송 시도: {} -> {}", websocketDestination, dto);
-
 			messagingTemplate.convertAndSend(websocketDestination, dto);
-
-			log.info("WebSocket으로 전송 완료: {}", websocketDestination);
-
 		} catch (Exception e) {
 			log.error("Redis 메시지 처리 중 오류", e);
 		}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#110 ]

### 로컬 병합
X

### 변경 사항
메시지를 제대로 파싱하지 못하는 문제 해결했습니다
- 지난 PR에서 레디스 키 네이밍 변경하며 채널이름 파싱하는 부분에 "chat-"을 "chat-pub:"으로 수정했습니다.
- 역직렬화대상을 dto->ChatMessage로 수정하였습니다
사용자 이름과 좋아요수를 포함하도록 수정하였습니다.

### 테스트 결과
테스트 코드에는 영향을 미치지 않는 수정이라 따로 첨부하지 않겠습니다.

