### PR TITLE
[#113] 전체, 추천, 라이브 세션 조회 응답 isLive 추가

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/session/dto/SessionListResponseDto.java
@@ -23,6 +23,9 @@ public class SessionListResponseDto {
 	@Schema(description = "세션 담기 여부", example = "true")
 	private Boolean isMySession;
 
+	@Schema(description = "세션 라이브 여부", example = "true")
+	private Boolean isLive;
+
 	@Schema(description = "연사 정보")
 	private SpeakerResponseDto speaker;
 
@@ -36,6 +39,7 @@ public class SessionListResponseDto {
 			.title(session.getTitle())
 			.summary(session.getSummary())
 			.isMySession(isMySession)
+			.isLive(session.getIsLive())
 			.speaker(speaker)
 			.tags(tags)
 			.build();

--- a/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/user/dto/UserProfileResponseDto.java
@@ -16,7 +16,7 @@ public class UserProfileResponseDto {
 	private final String job;
 	@Schema(description = "연차", example = "신입")
 	private final YearLevel years;
-	@Schema(description = "사용자의 관심 분야", example = "[\"클라우드\", \"데이터베이스\", \"자바스크립트\"]")
+	@Schema(description = "사용자의 관심 분야", example = "[\"대출\", \"디지털 뱅킹\", \"마이데이터\"]")
 	private final List<String> interests;
 
 	@Builder

--- a/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/session/service/SessionServiceTest.java
@@ -236,11 +236,13 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(content.get(0).getIsMySession()).isFalse(),
 
 			() -> assertThat(content.get(1).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(1).getIsLive()).isEqualTo(session4.getIsLive()),
 			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker4.getName()),
 			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(content.get(0).getIsMySession()).isFalse()
@@ -293,11 +295,13 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(content.get(0).getIsMySession()).isTrue(),
 
 			() -> assertThat(content.get(1).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(1).getIsLive()).isEqualTo(session4.getIsLive()),
 			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker4.getName()),
 			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(content.get(1).getIsMySession()).isFalse()
@@ -354,26 +358,32 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 
 			() -> assertThat(content.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(content.get(1).getIsLive()).isEqualTo(session2.getIsLive()),
 			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
 			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag2.getField()),
 
 			() -> assertThat(content.get(2).getTitle()).isEqualTo(session3.getTitle()),
+			() -> assertThat(content.get(2).getIsLive()).isEqualTo(session3.getIsLive()),
 			() -> assertThat(content.get(2).getSpeaker().getName()).isEqualTo(speaker3.getName()),
 			() -> assertThat(content.get(2).getTags().getField()).isEqualTo(tag3.getField()),
 
 			() -> assertThat(content.get(3).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(3).getIsLive()).isEqualTo(session4.getIsLive()),
 			() -> assertThat(content.get(3).getSpeaker().getName()).isEqualTo(speaker4.getName()),
 			() -> assertThat(content.get(3).getTags().getField()).isEqualTo(tag4.getField()),
 
 			() -> assertThat(content.get(4).getTitle()).isEqualTo(session5.getTitle()),
+			() -> assertThat(content.get(4).getIsLive()).isEqualTo(session5.getIsLive()),
 			() -> assertThat(content.get(4).getSpeaker().getName()).isEqualTo(speaker5.getName()),
 			() -> assertThat(content.get(4).getTags().getField()).isEqualTo(tag5.getField()),
 
 			() -> assertThat(content.get(5).getTitle()).isEqualTo(session6.getTitle()),
+			() -> assertThat(content.get(5).getIsLive()).isEqualTo(session6.getIsLive()),
 			() -> assertThat(content.get(5).getSpeaker().getName()).isEqualTo(speaker6.getName()),
 			() -> assertThat(content.get(5).getTags().getField()).isEqualTo(tag6.getField())
 		);
@@ -443,31 +453,37 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(content.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(content.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(content.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(content.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(content.get(0).getIsMySession()).isTrue(),
 
 			() -> assertThat(content.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(content.get(1).getIsLive()).isEqualTo(session2.getIsLive()),
 			() -> assertThat(content.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
 			() -> assertThat(content.get(1).getTags().getField()).isEqualTo(tag2.getField()),
 			() -> assertThat(content.get(1).getIsMySession()).isTrue(),
 
 			() -> assertThat(content.get(2).getTitle()).isEqualTo(session3.getTitle()),
+			() -> assertThat(content.get(2).getIsLive()).isEqualTo(session3.getIsLive()),
 			() -> assertThat(content.get(2).getSpeaker().getName()).isEqualTo(speaker3.getName()),
 			() -> assertThat(content.get(2).getTags().getField()).isEqualTo(tag3.getField()),
 			() -> assertThat(content.get(2).getIsMySession()).isFalse(),
 
 			() -> assertThat(content.get(3).getTitle()).isEqualTo(session4.getTitle()),
+			() -> assertThat(content.get(3).getIsLive()).isEqualTo(session4.getIsLive()),
 			() -> assertThat(content.get(3).getSpeaker().getName()).isEqualTo(speaker4.getName()),
 			() -> assertThat(content.get(3).getTags().getField()).isEqualTo(tag4.getField()),
 			() -> assertThat(content.get(3).getIsMySession()).isFalse(),
 
 			() -> assertThat(content.get(4).getTitle()).isEqualTo(session5.getTitle()),
+			() -> assertThat(content.get(4).getIsLive()).isEqualTo(session5.getIsLive()),
 			() -> assertThat(content.get(4).getSpeaker().getName()).isEqualTo(speaker5.getName()),
 			() -> assertThat(content.get(4).getTags().getField()).isEqualTo(tag5.getField()),
 			() -> assertThat(content.get(4).getIsMySession()).isFalse(),
 
 			() -> assertThat(content.get(5).getTitle()).isEqualTo(session6.getTitle()),
+			() -> assertThat(content.get(5).getIsLive()).isEqualTo(session6.getIsLive()),
 			() -> assertThat(content.get(5).getSpeaker().getName()).isEqualTo(speaker6.getName()),
 			() -> assertThat(content.get(5).getTags().getField()).isEqualTo(tag6.getField()),
 			() -> assertThat(content.get(5).getIsMySession()).isFalse()
@@ -503,10 +519,12 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(result.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(result.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(result.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(result.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 
 			() -> assertThat(result.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(result.get(1).getIsLive()).isEqualTo(session2.getIsLive()),
 			() -> assertThat(result.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
 			() -> assertThat(result.get(1).getTags().getField()).isEqualTo(tag2.getField())
 		);
@@ -552,11 +570,13 @@ class SessionServiceTest {
 
 		assertAll(
 			() -> assertThat(result.get(0).getTitle()).isEqualTo(session1.getTitle()),
+			() -> assertThat(result.get(0).getIsLive()).isEqualTo(session1.getIsLive()),
 			() -> assertThat(result.get(0).getSpeaker().getName()).isEqualTo(speaker1.getName()),
 			() -> assertThat(result.get(0).getTags().getField()).isEqualTo(tag1.getField()),
 			() -> assertThat(result.get(0).getIsMySession()).isTrue(),
 
 			() -> assertThat(result.get(1).getTitle()).isEqualTo(session2.getTitle()),
+			() -> assertThat(result.get(1).getIsLive()).isEqualTo(session2.getIsLive()),
 			() -> assertThat(result.get(1).getSpeaker().getName()).isEqualTo(speaker2.getName()),
 			() -> assertThat(result.get(1).getTags().getField()).isEqualTo(tag2.getField()),
 			() -> assertThat(result.get(1).getIsMySession()).isFalse()
@@ -728,7 +748,10 @@ class SessionServiceTest {
 		// then
 		assertThat(result).hasSize(3);
 		assertThat(result.get(0).getTitle()).isEqualTo(session1.getTitle());
+		assertThat(result.get(0).getIsLive()).isEqualTo(session1.getIsLive());
 		assertThat(result.get(1).getTitle()).isEqualTo(session2.getTitle());
+		assertThat(result.get(1).getIsLive()).isEqualTo(session2.getIsLive());
 		assertThat(result.get(2).getTitle()).isEqualTo(session3.getTitle());
+		assertThat(result.get(2).getIsLive()).isEqualTo(session3.getIsLive());
 	}
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 코드 리팩토링
- [x] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#113]

### 변경 사항
- 추천 세션 조회, 라이브 중인 세션 전체 조회, 세션 전체 조회 및 필터링에 isLive 추가
SessionListResponseDto를 모두 공유하는 것으로 확인되어 isLive 필드를 추가했습니다.

### 테스트 결과
![스크린샷 2025-03-29 오후 7 12 55](https://github.com/user-attachments/assets/276ab125-1e84-4098-861a-515d329e5992)
isLive 값 검증 추가 후 serviceTest 통과

