### PR TITLE
[#118] Redis에서 꺼낸 메시지 역직렬화 시 나노초 때문에 발생하던 오류 해결

### DIFF
--- a/src/main/java/eightplusone/bit/fit/global/config/RedisConfig.java
+++ b/src/main/java/eightplusone/bit/fit/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package eightplusone.bit.fit.global.config;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -9,6 +10,7 @@ import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
 import io.lettuce.core.TimeoutOptions;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -84,6 +86,11 @@ public class RedisConfig {
 		ObjectMapper objectMapper = new ObjectMapper();
 		objectMapper.registerModule(new JavaTimeModule());
 		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		// 💡 LocalDateTime 직렬화 시 나노초 제거 (기존 오류 해결용)
+		objectMapper.configOverride(LocalDateTime.class)
+			.setFormat(JsonFormat.Value.forPattern("yyyy-MM-dd'T'HH:mm:ss"));
+
 		return objectMapper;
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [ ] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#118 ]

### 로컬 병합
X

### 변경 사항
Redis에서 꺼낸 메시지 역직렬화 시 나노초 때문에 발생하던 오류 해결

### 테스트 결과
<img width="328" alt="image" src="https://github.com/user-attachments/assets/b9441afe-faef-45c4-a432-5cad3d018206" />
<img width="328" alt="image" src="https://github.com/user-attachments/assets/e13a1876-8f28-41bd-ae2c-bfe0d35958d5" />


