### PR TITLE
[#130] 최근 메시지 조회 API 수정

### DIFF
--- a/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/controller/ChatController.java
@@ -62,10 +62,10 @@ public class ChatController {
 		@ApiResponse(responseCode = "200", description = "성공적으로 메시지를 반환함")
 	})
 	@GetMapping("/{sessionId}/messages")
-	public ResponseEntity<List<Object>> getRecentMessages(
+	public ResponseEntity<List<ChatMessageDto>> getRecentMessages(
 		@Parameter(description = "채팅 세션 ID", example = "1234") @PathVariable String sessionId
 	) {
-		List<Object> messages = chatService.getRecentMessages(sessionId);
+		List<ChatMessageDto> messages = chatService.getRecentMessages(sessionId);
 		return ResponseEntity.ok(messages);
 	}
 

--- a/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/dto/ChatMessageDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import eightplusone.bit.fit.domain.chat.enums.ChatCategory;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -19,6 +20,7 @@ public class ChatMessageDto {
 	private LocalDateTime timestamp;
 	private int likes;
 
+	@Builder
 	@JsonCreator
 	public ChatMessageDto(
 		@JsonProperty("messageId") String messageId,

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -106,11 +106,35 @@ public class ChatService {
 	}
 
 	// 특정 채팅방의 최근 메시지 조회
-	public List<Object> getRecentMessages(String sessionId) {
+	public List<ChatMessageDto> getRecentMessages(String sessionId) {
 		if (!chatRepository.existsBySessionId(sessionId)) {
 			throw new CustomException(ErrorCode.CHAT_SESSION_NOT_FOUND);
 		}
-		return chatRepository.getRecentMessages(sessionId);
+
+		List<Object> rawMessages = chatRepository.getRecentMessages(sessionId);
+		return rawMessages.stream()
+			.map(obj -> {
+				if (obj instanceof ChatMessage message) {
+					String userName = userRedisRepository.getUserName(message.getUserId());
+					Double score = redisTemplate.opsForZSet()
+						.score("questions:session:" + sessionId, message.getMessageId());
+					int likeCount = score != null ? score.intValue() : 0;
+
+					return new ChatMessageDto(
+						message.getMessageId(),
+						message.getCategory(),
+						message.getMessage(),
+						userName != null ? userName : "알 수 없음",
+						message.getUserId(),
+						message.getSessionId(),
+						message.getTimestamp(),
+						likeCount
+					);
+				}
+				return null;
+			})
+			.filter(Objects::nonNull)
+			.toList();
 	}
 
 	// 특정 채팅방 데이터 삭제 (강연 종료 후)

--- a/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
+++ b/src/main/java/eightplusone/bit/fit/domain/chat/service/ChatService.java
@@ -89,16 +89,16 @@ public class ChatService {
 		}
 
 		// ChatMessageDto로 다시 만들어서 발행 (messageId, timestamp 포함!)
-		ChatMessageDto dtoToSend = new ChatMessageDto(
-			message.getMessageId(),
-			message.getCategory(),
-			message.getMessage(),
-			name,
-			message.getUserId(),
-			message.getSessionId(),
-			message.getTimestamp(),
-			0
-		);
+		ChatMessageDto dtoToSend = ChatMessageDto.builder()
+			.messageId(message.getMessageId())
+			.category(message.getCategory())
+			.message(message.getMessage())
+			.name(name)
+			.userId(message.getUserId())
+			.sessionId(message.getSessionId())
+			.timestamp(message.getTimestamp())
+			.likes(0)
+			.build();
 
 		String redisKey = "chat-pub:" + sessionId;
 		log.info("Redis 발행 메세지 : {} -> {}", redisKey, dtoToSend);
@@ -120,16 +120,16 @@ public class ChatService {
 						.score("questions:session:" + sessionId, message.getMessageId());
 					int likeCount = score != null ? score.intValue() : 0;
 
-					return new ChatMessageDto(
-						message.getMessageId(),
-						message.getCategory(),
-						message.getMessage(),
-						userName != null ? userName : "알 수 없음",
-						message.getUserId(),
-						message.getSessionId(),
-						message.getTimestamp(),
-						likeCount
-					);
+					return ChatMessageDto.builder()
+						.messageId(message.getMessageId())
+						.category(message.getCategory())
+						.message(message.getMessage())
+						.name(userName != null ? userName : "알 수 없음")
+						.userId(message.getUserId())
+						.sessionId(message.getSessionId())
+						.timestamp(message.getTimestamp())
+						.likes(likeCount)
+						.build();
 				}
 				return null;
 			})
@@ -260,16 +260,16 @@ public class ChatService {
 
 				log.info("🔍 userRedisRepository.getUserName({}) → {}", msg.getUserId(), userName);
 
-				return new ChatMessageDto(
-					msg.getMessageId(),
-					msg.getCategory(),
-					msg.getMessage(),
-					userName != null ? userName : "알 수 없음",
-					msg.getUserId(),
-					msg.getSessionId(),
-					msg.getTimestamp(),
-					likeCount
-				);
+				return ChatMessageDto.builder()
+					.messageId(msg.getMessageId())
+					.category(msg.getCategory())
+					.message(msg.getMessage())
+					.name(userName != null ? userName : "알 수 없음")
+					.userId(msg.getUserId())
+					.sessionId(msg.getSessionId())
+					.timestamp(msg.getTimestamp())
+					.likes(likeCount)
+					.build();
 			})
 			.collect(Collectors.toList());
 	}
@@ -298,16 +298,17 @@ public class ChatService {
 					Double score = redisTemplate.opsForZSet().score(zsetKey, messageId);
 					int likeCount = score != null ? score.intValue() : 0;
 
-					return new ChatMessageDto(
-						msg.getMessageId(),
-						msg.getCategory(),
-						msg.getMessage(),
-						userName != null ? userName : "알 수 없음",
-						msg.getUserId(),
-						msg.getSessionId(),
-						msg.getTimestamp(),
-						likeCount
-					);
+					return ChatMessageDto.builder()
+						.messageId(msg.getMessageId())
+						.category(msg.getCategory())
+						.message(msg.getMessage())
+						.name(userName != null ? userName : "알 수 없음")
+						.userId(msg.getUserId())
+						.sessionId(msg.getSessionId())
+						.timestamp(msg.getTimestamp())
+						.likes(likeCount)
+						.build();
+
 				} catch (JsonProcessingException e) {
 					log.error("❌ 메시지 역직렬화 실패: {}", e.getMessage());
 					return null;

--- a/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/eightplusone/bit/fit/domain/chat/service/ChatServiceTest.java
@@ -247,12 +247,23 @@ class ChatServiceTest {
 	// 특정 채팅방의 최근 메시지를 정상적으로 조회할 수 있는지 확인
 	@Test
 	void getRecentMessages_success() {
+		Long sessionId = 1L;
+
 		when(chatRepository.existsBySessionId(String.valueOf(sessionId))).thenReturn(true);
 		when(chatRepository.getRecentMessages(String.valueOf(sessionId))).thenReturn(List.of(chatMessage));
 
-		List<Object> messages = chatService.getRecentMessages(String.valueOf(sessionId));
+		ZSetOperations<String, Object> zSetOps = mock(ZSetOperations.class);
+		when(redisTemplate.opsForZSet()).thenReturn(zSetOps);
+		when(zSetOps.score("questions:session:" + sessionId, chatMessage.getMessageId())).thenReturn(0.0);
+
+		when(userRedisRepository.getUserName(chatMessage.getUserId())).thenReturn("테스터");
+
+		List<ChatMessageDto> messages = chatService.getRecentMessages(String.valueOf(sessionId));
 
 		assertThat(messages).isNotEmpty();
+		assertThat(messages.get(0).getName()).isEqualTo("테스터");
+		assertThat(messages.get(0).getLikes()).isEqualTo(0);
+
 		verify(chatRepository, times(1)).getRecentMessages(String.valueOf(sessionId));
 	}
 


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 문서 수정
- [X] 코드 리팩토링
- [ ] 테스트 코드 추가 및 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
dev

### 이슈
[#130 ]

### 로컬 병합
X

### 변경 사항
1. 최근 메시지 불러오는 메서드에서 dto 로 변환하도록 수정해 userId에 매핑된 name 필드 받아올 수 있도록 수정
2. 빌더 패턴 적용 리팩토링

### 테스트 결과
![image](https://github.com/user-attachments/assets/d82b54a5-b775-44fe-b1e3-f91781e63a09)
![image](https://github.com/user-attachments/assets/876e6280-ffd3-4ba6-9372-208703eb8746)
